### PR TITLE
CorrelationId enhancements

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## 4.0.1
+- CorrelationId is now created automatically and is being passed to newly published events.
+- Added method overload enabling you to publish a message with a specific correlationId.
+
 ## 4.0.0
 - refactored the entire project to use [Azure.Messaging.ServiceBus](https://www.nuget.org/packages/Azure.Messaging.ServiceBus/)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
-## 4.0.1
+## 4.1.0
 - CorrelationId is now created automatically and is being passed to newly published events.
 - Added method overload enabling you to publish a message with a specific correlationId.
 

--- a/src/Ev.ServiceBus.Abstractions/Dispatch.cs
+++ b/src/Ev.ServiceBus.Abstractions/Dispatch.cs
@@ -9,5 +9,6 @@ public sealed class Dispatch
 
     public object Payload { get; }
     public string? SessionId { get; set; }
+    public string? CorrelationId { get; set; }
 }
 

--- a/src/Ev.ServiceBus.Abstractions/IMessageContext.cs
+++ b/src/Ev.ServiceBus.Abstractions/IMessageContext.cs
@@ -1,0 +1,7 @@
+namespace Ev.ServiceBus.Abstractions;
+
+public interface IMessageContext
+{
+    public string? SessionId { get; set; }
+    public string? CorrelationId { get; set; }
+}

--- a/src/Ev.ServiceBus.Abstractions/IMessagePublisher.cs
+++ b/src/Ev.ServiceBus.Abstractions/IMessagePublisher.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Ev.ServiceBus.Abstractions
 {
     public interface IMessagePublisher
@@ -16,5 +18,13 @@ namespace Ev.ServiceBus.Abstractions
         /// <param name="sessionId">The sessionId to attach to the outgoing message</param>
         /// <typeparam name="TMessagePayload">A type of object that is registered within Ev.ServiceBus</typeparam>
         void Publish<TMessagePayload>(TMessagePayload messageDto, string sessionId);
+
+        /// <summary>
+        /// Temporarily stores the object to send through Service Bus until <see cref="IMessageDispatcher.ExecuteDispatches"/> is called.
+        /// </summary>
+        /// <param name="messageDto">The object to send through Service Bus</param>
+        /// <param name="messageContextConfiguration">Configurator of message context</param>
+        /// <typeparam name="TMessagePayload">A type of object that is registered within Ev.ServiceBus</typeparam>
+        void Publish<TMessagePayload>(TMessagePayload messageDto, Action<IMessageContext> messageContextConfiguration);
     }
 }

--- a/src/Ev.ServiceBus.Abstractions/MessageReception/IMessageMetadataAccessor.cs
+++ b/src/Ev.ServiceBus.Abstractions/MessageReception/IMessageMetadataAccessor.cs
@@ -4,13 +4,3 @@ public interface IMessageMetadataAccessor
 {
     public IMessageMetadata? Metadata { get; }
 }
-
-public class MessageMetadataAccessor : IMessageMetadataAccessor
-{
-    public void SetData(MessageContext context)
-    {
-        Metadata = new MessageMetadata(context.Message, context.CancellationToken);
-    }
-
-    public IMessageMetadata? Metadata { get; private set; }
-}

--- a/src/Ev.ServiceBus/Dispatch/MessageContext.cs
+++ b/src/Ev.ServiceBus/Dispatch/MessageContext.cs
@@ -1,0 +1,9 @@
+﻿using Ev.ServiceBus.Abstractions;
+
+namespace Ev.ServiceBus.Dispatch;
+
+internal class MessageContext : IMessageContext
+{
+    public string? CorrelationId { get; set; }
+    public string? SessionId { get; set; }
+}

--- a/src/Ev.ServiceBus/Dispatch/MessageDispatcher.cs
+++ b/src/Ev.ServiceBus/Dispatch/MessageDispatcher.cs
@@ -57,5 +57,31 @@ namespace Ev.ServiceBus.Dispatch
                 SessionId = sessionId
             });
         }
+
+        /// <inheritdoc />
+        public void Publish<TMessagePayload>(
+            TMessagePayload messageDto,
+            Action<IMessageContext> messageContextConfiguration)
+        {
+            if (messageDto == null)
+            {
+                throw new ArgumentNullException(nameof(messageDto));
+            }
+
+            if (messageContextConfiguration == null)
+            {
+                throw new ArgumentNullException(nameof(messageContextConfiguration));
+            }
+
+            var context = new MessageContext();
+
+            messageContextConfiguration.Invoke(context);
+
+            _dispatchesToSend.Add(new Abstractions.Dispatch(messageDto)
+            {
+                SessionId = context.SessionId,
+                CorrelationId = context.CorrelationId
+            });
+        }
     }
 }

--- a/src/Ev.ServiceBus/Management/MessageMetadataAccessor.cs
+++ b/src/Ev.ServiceBus/Management/MessageMetadataAccessor.cs
@@ -1,33 +1,15 @@
 using System.Threading;
+using Ev.ServiceBus.Abstractions;
 using Ev.ServiceBus.Abstractions.MessageReception;
 
 namespace Ev.ServiceBus.Management;
 
 internal class MessageMetadataAccessor : IMessageMetadataAccessor
 {
-    private static readonly AsyncLocal<MessageMetadataHolder> MessageMetadataCurrent =
-        new AsyncLocal<MessageMetadataHolder>();
+    public IMessageMetadata? Metadata { get; private set; }
 
-    public IMessageMetadata? Metadata
+    public void SetData(MessageContext context)
     {
-        get => MessageMetadataCurrent.Value?.Metadata;
-        set
-        {
-            var holder = MessageMetadataCurrent.Value;
-            if (holder != null)
-            {
-                holder.Metadata = null;
-            }
-
-            if (value != null)
-            {
-                MessageMetadataCurrent.Value = new MessageMetadataHolder { Metadata = value };
-            }
-        }
-    }
-
-    private class MessageMetadataHolder
-    {
-        public IMessageMetadata? Metadata;
+        Metadata = new MessageMetadata(context.Message, context.CancellationToken);
     }
 }

--- a/src/Ev.ServiceBus/Management/MessageMetadataAccessor.cs
+++ b/src/Ev.ServiceBus/Management/MessageMetadataAccessor.cs
@@ -1,0 +1,33 @@
+using System.Threading;
+using Ev.ServiceBus.Abstractions.MessageReception;
+
+namespace Ev.ServiceBus.Management;
+
+internal class MessageMetadataAccessor : IMessageMetadataAccessor
+{
+    private static readonly AsyncLocal<MessageMetadataHolder> MessageMetadataCurrent =
+        new AsyncLocal<MessageMetadataHolder>();
+
+    public IMessageMetadata? Metadata
+    {
+        get => MessageMetadataCurrent.Value?.Metadata;
+        set
+        {
+            var holder = MessageMetadataCurrent.Value;
+            if (holder != null)
+            {
+                holder.Metadata = null;
+            }
+
+            if (value != null)
+            {
+                MessageMetadataCurrent.Value = new MessageMetadataHolder { Metadata = value };
+            }
+        }
+    }
+
+    private class MessageMetadataHolder
+    {
+        public IMessageMetadata? Metadata;
+    }
+}

--- a/src/Ev.ServiceBus/Management/Wrappers/ReceiverWrapper.cs
+++ b/src/Ev.ServiceBus/Management/Wrappers/ReceiverWrapper.cs
@@ -7,8 +7,11 @@ using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
 using Ev.ServiceBus.Abstractions;
 using Ev.ServiceBus.Abstractions.MessageReception;
+using Ev.ServiceBus.Dispatch;
+using Ev.ServiceBus.Management;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using MessageContext = Ev.ServiceBus.Abstractions.MessageContext;
 
 namespace Ev.ServiceBus;
 
@@ -146,8 +149,10 @@ public class ReceiverWrapper : IWrapper
         using (_logger.BeginScope(scopeValues))
         using (var scope = _provider.CreateScope())
         {
-            var metadataAccessor = (MessageMetadataAccessor)scope.ServiceProvider.GetRequiredService<IMessageMetadataAccessor>();
-            metadataAccessor.SetData(context);
+            var metadataAccessor =
+                (MessageMetadataAccessor)scope.ServiceProvider.GetRequiredService<IMessageMetadataAccessor>();
+            var metadata = new MessageMetadata(context.Message, context.CancellationToken);
+            metadataAccessor.Metadata = metadata;
             var listeners = scope.ServiceProvider.GetRequiredService<IEnumerable<IServiceBusEventListener>>();
             var executionStartedArgs = new ExecutionStartedArgs(ClientType, ResourceId, _composedOptions.MessageHandlerType, context.Message);
             foreach (var listener in listeners)

--- a/src/Ev.ServiceBus/Management/Wrappers/ReceiverWrapper.cs
+++ b/src/Ev.ServiceBus/Management/Wrappers/ReceiverWrapper.cs
@@ -151,8 +151,7 @@ public class ReceiverWrapper : IWrapper
         {
             var metadataAccessor =
                 (MessageMetadataAccessor)scope.ServiceProvider.GetRequiredService<IMessageMetadataAccessor>();
-            var metadata = new MessageMetadata(context.Message, context.CancellationToken);
-            metadataAccessor.Metadata = metadata;
+            metadataAccessor.SetData(context);
             var listeners = scope.ServiceProvider.GetRequiredService<IEnumerable<IServiceBusEventListener>>();
             var executionStartedArgs = new ExecutionStartedArgs(ClientType, ResourceId, _composedOptions.MessageHandlerType, context.Message);
             foreach (var listener in listeners)

--- a/src/Ev.ServiceBus/ServiceCollectionExtensions.cs
+++ b/src/Ev.ServiceBus/ServiceCollectionExtensions.cs
@@ -51,12 +51,12 @@ namespace Ev.ServiceBus
 
             RegisterMessageReceptionServices(services);
 
+            services.TryAddSingleton<IMessageMetadataAccessor, MessageMetadataAccessor>();
         }
 
         private static void RegisterMessageReceptionServices(IServiceCollection services)
         {
             services.TryAddScoped<MessageReceptionHandler>();
-            services.TryAddScoped<IMessageMetadataAccessor, MessageMetadataAccessor>();
         }
 
         private static void RegisterMessageDispatchServices(IServiceCollection services)

--- a/src/Ev.ServiceBus/ServiceCollectionExtensions.cs
+++ b/src/Ev.ServiceBus/ServiceCollectionExtensions.cs
@@ -51,7 +51,7 @@ namespace Ev.ServiceBus
 
             RegisterMessageReceptionServices(services);
 
-            services.TryAddSingleton<IMessageMetadataAccessor, MessageMetadataAccessor>();
+            services.TryAddScoped<IMessageMetadataAccessor, MessageMetadataAccessor>();
         }
 
         private static void RegisterMessageReceptionServices(IServiceCollection services)
@@ -64,7 +64,7 @@ namespace Ev.ServiceBus
             services.TryAddScoped<MessageDispatcher>();
             services.TryAddScoped<IMessagePublisher>(provider => provider.GetRequiredService<MessageDispatcher>());
             services.TryAddScoped<IMessageDispatcher>(provider => provider.GetRequiredService<MessageDispatcher>());
-            services.TryAddSingleton<IDispatchSender, DispatchSender>();
+            services.TryAddScoped<IDispatchSender, DispatchSender>();
         }
 
         private static void RegisterResourceManagementServices(IServiceCollection services)

--- a/tests/Ev.ServiceBus.UnitTests/MessageMetadataTests.cs
+++ b/tests/Ev.ServiceBus.UnitTests/MessageMetadataTests.cs
@@ -15,7 +15,7 @@ namespace Ev.ServiceBus.UnitTests
     public class MessageMetadataTests
     {
         [Fact]
-        public async Task AScopeIsCreatedForEachMessageReceived()
+        public async Task MetadataIsProperlySet()
         {
             var composer = new Composer();
 
@@ -45,6 +45,8 @@ namespace Ev.ServiceBus.UnitTests
                 .Contain(UserProperties.MessageTypeProperty)
                 .And
                 .Contain(UserProperties.EventTypeIdProperty);
+            metadata.CorrelationId.Should().Be("8B4C4C3C-482A-4688-8458-AFF9998C0A12");
+            metadata.SessionId.Should().Be("ABB8761B-C22E-407E-801C-DFAF68916F04");
         }
 
         private async Task SimulateEventReception(
@@ -61,7 +63,9 @@ namespace Ev.ServiceBus.UnitTests
                 {
                     { UserProperties.MessageTypeProperty, "IntegrationEvent" },
                     { UserProperties.EventTypeIdProperty, "Payload" }
-                }
+                },
+                CorrelationId = "8B4C4C3C-482A-4688-8458-AFF9998C0A12",
+                SessionId = "ABB8761B-C22E-407E-801C-DFAF68916F04"
             };
 
             // Necessary to simulate the reception of the message


### PR DESCRIPTION
CorrelationId is now generated if null.
Introduced new method on MessagePublisher where you can pass message context configuration (CorrelationId and SessionId).
CorrelationId is now passed to published messages.
Refactored MessageMetadataAccessor to singleton with usage of LocalAsync.