### PR TITLE
MessageId customization

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## 4.7.0
+- Added the MessageId property to the MessageContext class to allow MessageId customization on publish
+
 ## 4.6.1
 - Made some internal methods public in IServiceBusRegistry class
 

--- a/src/Ev.ServiceBus.Abstractions/Dispatch.cs
+++ b/src/Ev.ServiceBus.Abstractions/Dispatch.cs
@@ -10,5 +10,6 @@ public sealed class Dispatch
     public object Payload { get; }
     public string? SessionId { get; set; }
     public string? CorrelationId { get; set; }
+    public string? MessageId { get; set; }
 }
 

--- a/src/Ev.ServiceBus.Abstractions/IMessageContext.cs
+++ b/src/Ev.ServiceBus.Abstractions/IMessageContext.cs
@@ -4,4 +4,5 @@ public interface IMessageContext
 {
     public string? SessionId { get; set; }
     public string? CorrelationId { get; set; }
+    public string? MessageId { get; set; }
 }

--- a/src/Ev.ServiceBus/Dispatch/DispatchSender.cs
+++ b/src/Ev.ServiceBus/Dispatch/DispatchSender.cs
@@ -195,6 +195,11 @@ namespace Ev.ServiceBus.Dispatch
             message.SessionId = dispatch.SessionId;
             message.CorrelationId = dispatch.CorrelationId ?? originalCorrelationId;
 
+            if (!string.IsNullOrWhiteSpace(dispatch.MessageId))
+            {
+                message.MessageId = dispatch.MessageId;
+            }
+
             foreach (var customizer in registration.OutgoingMessageCustomizers)
             {
                 customizer?.Invoke(message, dispatch.Payload);

--- a/src/Ev.ServiceBus/Dispatch/MessageContext.cs
+++ b/src/Ev.ServiceBus/Dispatch/MessageContext.cs
@@ -6,4 +6,5 @@ internal class MessageContext : IMessageContext
 {
     public string? CorrelationId { get; set; }
     public string? SessionId { get; set; }
+    public string? MessageId { get; set; }
 }

--- a/src/Ev.ServiceBus/Dispatch/MessageDispatcher.cs
+++ b/src/Ev.ServiceBus/Dispatch/MessageDispatcher.cs
@@ -80,7 +80,8 @@ namespace Ev.ServiceBus.Dispatch
             _dispatchesToSend.Add(new Abstractions.Dispatch(messageDto)
             {
                 SessionId = context.SessionId,
-                CorrelationId = context.CorrelationId
+                CorrelationId = context.CorrelationId,
+                MessageId = context.MessageId
             });
         }
     }


### PR DESCRIPTION
This Pr introduces minimal changes to allow the Ev.ServiceBus user to be able to set the messageId if needed using the MessageContext parameter in the Publish Method.

If no context or the messageId is null or empty, it will work as before. Using the generated MessageId.