### PR TITLE
Support for DiagnosticID (traceparent) values in case of service buss message publisher/dispatcher mechanism

### DIFF
--- a/docs/AdvancedScenarios.md
+++ b/docs/AdvancedScenarios.md
@@ -131,3 +131,29 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
     });
 }
 ```
+
+## Distributed tracing and correlation through Service Bus messaging support in case of publish / dispatch mechanism
+Distributed tracing and correlation through Service Bus messaging is automatically supported by the library. It is supported according assumptions described [here](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-end-to-end-tracing?tabs=net-standard-sdk-2).
+While message publishing `treceparent` value is automatically get from `Activity.Current.Id` in case if any publication is executed in any Activity scope.
+If do you need pass another value manually while the publication. You can do this by set `IMessageContext` - what is possible in by using one of overloaded `Publish` method of `IMessagePublisher` interface implementation.
+
+```csharp
+public class MyMessageSender
+        {
+
+            private readonly IMessagePublisher _eventPublisher;
+
+            public MyMessageSender(IMessagePublisher eventPublisher)
+            {
+                _eventPublisher = eventPublisher;
+            }
+
+            public async Task PublishMyMessage(MyEvent @event, string myCustomDiagnosticsId)
+            {
+                _eventPublisher.Publish(
+                    @event,
+                    // here you can pas the function that will set your custom value of diagnostic id
+                    context => context.DiagnosticId = myCustomDiagnosticsId);
+            }
+        }
+```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ## 4.8.0
-- Added DiagnosticID (traceparent) support for publisher / dispatcher
+- Added DiagnosticID (traceparent) support for publisher / dispatcher in case of end to end tracing (according: [Distributed tracing and correlation through Service Bus messaging](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-end-to-end-tracing?tabs=net-standard-sdk-2))  
 
 ## 4.7.0
 - Added the MessageId property to the MessageContext class to allow MessageId customization on publish

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## 4.8.0
+- Added DiagnosticID (traceparent) support for publisher / dispatcher
+
 ## 4.7.0
 - Added the MessageId property to the MessageContext class to allow MessageId customization on publish
 

--- a/src/Ev.ServiceBus.Abstractions/Dispatch.cs
+++ b/src/Ev.ServiceBus.Abstractions/Dispatch.cs
@@ -11,5 +11,6 @@ public sealed class Dispatch
     public string? SessionId { get; set; }
     public string? CorrelationId { get; set; }
     public string? MessageId { get; set; }
+    public string? DiagnosticId { get; set; }
 }
 

--- a/src/Ev.ServiceBus.Abstractions/Extensions/DiagnosticIdExtension.cs
+++ b/src/Ev.ServiceBus.Abstractions/Extensions/DiagnosticIdExtension.cs
@@ -1,0 +1,28 @@
+﻿using Azure.Messaging.ServiceBus;
+
+namespace Ev.ServiceBus.Abstractions.Extensions;
+
+public static class DiagnosticIdExtension
+{
+    private const string DiagnosticIdKey = "Diagnostic-Id";
+    public static string? GetDiagnosticId(this ServiceBusReceivedMessage message)
+    {
+        return message.ApplicationProperties.ContainsKey(DiagnosticIdKey)
+            ? message.ApplicationProperties[DiagnosticIdKey].ToString()
+            : null;
+    }
+
+    public static string? GetDiagnosticId(this ServiceBusMessage message)
+    {
+        return message.ApplicationProperties.ContainsKey(DiagnosticIdKey)
+            ? message.ApplicationProperties[DiagnosticIdKey].ToString()
+            : null;
+    }
+
+    public static void SetDiagnosticIdIfIsNot(this ServiceBusMessage message, string diagnosticId)
+    {
+        if(message.ApplicationProperties.ContainsKey(DiagnosticIdKey))
+            return;
+        message.ApplicationProperties.Add(DiagnosticIdKey, diagnosticId);
+    }
+}

--- a/src/Ev.ServiceBus.Abstractions/IMessageContext.cs
+++ b/src/Ev.ServiceBus.Abstractions/IMessageContext.cs
@@ -5,4 +5,5 @@ public interface IMessageContext
     public string? SessionId { get; set; }
     public string? CorrelationId { get; set; }
     public string? MessageId { get; set; }
+    public string? DiagnosticId { get; set; }
 }

--- a/src/Ev.ServiceBus.Abstractions/IMessageContext.cs
+++ b/src/Ev.ServiceBus.Abstractions/IMessageContext.cs
@@ -5,5 +5,8 @@ public interface IMessageContext
     public string? SessionId { get; set; }
     public string? CorrelationId { get; set; }
     public string? MessageId { get; set; }
+    /// <summary>
+    /// Unique identifier of call from producer to the queue or topic. Refer to W3C Trace-Context traceparent header for the format
+    /// </summary>
     public string? DiagnosticId { get; set; }
 }

--- a/src/Ev.ServiceBus.Abstractions/IMessagePublisher.cs
+++ b/src/Ev.ServiceBus.Abstractions/IMessagePublisher.cs
@@ -16,8 +16,9 @@ namespace Ev.ServiceBus.Abstractions
         /// </summary>
         /// <param name="messageDto">The object to send through Service Bus</param>
         /// <param name="sessionId">The sessionId to attach to the outgoing message</param>
+        /// <param name="diagnosticId">Unique identifier of an external call from producer to the queue. Refer to W3C Trace-Context traceparent header for the format</param>
         /// <typeparam name="TMessagePayload">A type of object that is registered within Ev.ServiceBus</typeparam>
-        void Publish<TMessagePayload>(TMessagePayload messageDto, string sessionId);
+        void Publish<TMessagePayload>(TMessagePayload messageDto, string sessionId, string? diagnosticId = null);
 
         /// <summary>
         /// Temporarily stores the object to send through Service Bus until <see cref="IMessageDispatcher.ExecuteDispatches"/> is called.

--- a/src/Ev.ServiceBus.Abstractions/IMessagePublisher.cs
+++ b/src/Ev.ServiceBus.Abstractions/IMessagePublisher.cs
@@ -16,9 +16,8 @@ namespace Ev.ServiceBus.Abstractions
         /// </summary>
         /// <param name="messageDto">The object to send through Service Bus</param>
         /// <param name="sessionId">The sessionId to attach to the outgoing message</param>
-        /// <param name="diagnosticId">Unique identifier of an external call from producer to the queue. Refer to W3C Trace-Context traceparent header for the format</param>
         /// <typeparam name="TMessagePayload">A type of object that is registered within Ev.ServiceBus</typeparam>
-        void Publish<TMessagePayload>(TMessagePayload messageDto, string sessionId, string? diagnosticId = null);
+        void Publish<TMessagePayload>(TMessagePayload messageDto, string sessionId);
 
         /// <summary>
         /// Temporarily stores the object to send through Service Bus until <see cref="IMessageDispatcher.ExecuteDispatches"/> is called.

--- a/src/Ev.ServiceBus.Abstractions/MessageReception/IMessageMetadata.cs
+++ b/src/Ev.ServiceBus.Abstractions/MessageReception/IMessageMetadata.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
+using Ev.ServiceBus.Abstractions.Extensions;
 
 namespace Ev.ServiceBus.Abstractions.MessageReception;
 
@@ -11,6 +12,7 @@ public interface IMessageMetadata
     public string ContentType { get; }
     public string CorrelationId { get; }
     public string SessionId { get; }
+    public string? DiagnosticId { get; }
     public CancellationToken CancellationToken { get; }
     public IReadOnlyDictionary<string, object> ApplicationProperties { get; }
     public string MessageId { get; }
@@ -143,6 +145,7 @@ public class MessageMetadata : IMessageMetadata
     public string DeadLetterErrorDescription => _message.DeadLetterErrorDescription;
     public string SessionId => _message.SessionId;
     public string CorrelationId => _message.CorrelationId;
+    public string? DiagnosticId => _message.GetDiagnosticId();
     public string ContentType => _message.ContentType;
     public IReadOnlyDictionary<string, object> ApplicationProperties => _message.ApplicationProperties;
     public CancellationToken CancellationToken { get; }

--- a/src/Ev.ServiceBus/Dispatch/DispatchSender.cs
+++ b/src/Ev.ServiceBus/Dispatch/DispatchSender.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
 using Ev.ServiceBus.Abstractions;
+using Ev.ServiceBus.Abstractions.Extensions;
 using Ev.ServiceBus.Abstractions.MessageReception;
 using Ev.ServiceBus.Management;
 
@@ -194,7 +195,8 @@ namespace Ev.ServiceBus.Dispatch
 
             message.SessionId = dispatch.SessionId;
             message.CorrelationId = dispatch.CorrelationId ?? originalCorrelationId;
-
+            if(dispatch.DiagnosticId != null)
+                message.SetDiagnosticIdIfIsNot(dispatch.DiagnosticId);
             if (!string.IsNullOrWhiteSpace(dispatch.MessageId))
             {
                 message.MessageId = dispatch.MessageId;

--- a/src/Ev.ServiceBus/Dispatch/MessageContext.cs
+++ b/src/Ev.ServiceBus/Dispatch/MessageContext.cs
@@ -7,4 +7,5 @@ internal class MessageContext : IMessageContext
     public string? CorrelationId { get; set; }
     public string? SessionId { get; set; }
     public string? MessageId { get; set; }
+    public string? DiagnosticId { get; set; }
 }

--- a/src/Ev.ServiceBus/Dispatch/MessageContext.cs
+++ b/src/Ev.ServiceBus/Dispatch/MessageContext.cs
@@ -7,5 +7,8 @@ internal class MessageContext : IMessageContext
     public string? CorrelationId { get; set; }
     public string? SessionId { get; set; }
     public string? MessageId { get; set; }
+    /// <summary>
+    /// Unique identifier of call from producer to the queue or topic. Refer to W3C Trace-Context traceparent header for the format
+    /// </summary>
     public string? DiagnosticId { get; set; }
 }

--- a/src/Ev.ServiceBus/Dispatch/MessageDispatcher.cs
+++ b/src/Ev.ServiceBus/Dispatch/MessageDispatcher.cs
@@ -44,7 +44,7 @@ namespace Ev.ServiceBus.Dispatch
         }
 
         /// <inheritdoc />
-        public void Publish<TMessagePayload>(TMessagePayload messageDto, string sessionId, string? diagnosticId = null)
+        public void Publish<TMessagePayload>(TMessagePayload messageDto, string sessionId)
         {
             if (messageDto == null)
             {
@@ -59,7 +59,7 @@ namespace Ev.ServiceBus.Dispatch
             _dispatchesToSend.Add(new Abstractions.Dispatch(messageDto)
             {
                 SessionId = sessionId,
-                DiagnosticId = diagnosticId ?? Activity.Current?.Id
+                DiagnosticId = Activity.Current?.Id
             });
         }
 

--- a/src/Ev.ServiceBus/Dispatch/MessageDispatcher.cs
+++ b/src/Ev.ServiceBus/Dispatch/MessageDispatcher.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Ev.ServiceBus.Abstractions;
@@ -36,11 +37,14 @@ namespace Ev.ServiceBus.Dispatch
                 throw new ArgumentNullException(nameof(messageDto));
             }
 
-            _dispatchesToSend.Add(new Abstractions.Dispatch(messageDto));
+            _dispatchesToSend.Add(new Abstractions.Dispatch(messageDto)
+            {
+                DiagnosticId = Activity.Current?.Id
+            });
         }
 
         /// <inheritdoc />
-        public void Publish<TMessagePayload>(TMessagePayload messageDto, string sessionId)
+        public void Publish<TMessagePayload>(TMessagePayload messageDto, string sessionId, string? diagnosticId = null)
         {
             if (messageDto == null)
             {
@@ -54,7 +58,8 @@ namespace Ev.ServiceBus.Dispatch
 
             _dispatchesToSend.Add(new Abstractions.Dispatch(messageDto)
             {
-                SessionId = sessionId
+                SessionId = sessionId,
+                DiagnosticId = diagnosticId ?? Activity.Current?.Id
             });
         }
 
@@ -81,7 +86,8 @@ namespace Ev.ServiceBus.Dispatch
             {
                 SessionId = context.SessionId,
                 CorrelationId = context.CorrelationId,
-                MessageId = context.MessageId
+                MessageId = context.MessageId,
+                DiagnosticId = context.DiagnosticId ?? Activity.Current?.Id
             });
         }
     }

--- a/tests/Ev.ServiceBus.TestHelpers/DiagnosticIdHelper.cs
+++ b/tests/Ev.ServiceBus.TestHelpers/DiagnosticIdHelper.cs
@@ -1,0 +1,15 @@
+﻿using System.Diagnostics;
+
+namespace Ev.ServiceBus.TestHelpers;
+
+public static class DiagnosticIdHelper
+{
+    public static string GetNewId()
+    {
+        var activity = new Activity("no activity");
+        activity.Start();
+        var id = activity.Id;
+        activity.Stop();
+        return id;
+    }
+}


### PR DESCRIPTION
Support for DiagnosticID (traceparent) values in case of service buss message publisher/dispatcher mechanism was added. (Refer to [W3C Trace-Context traceparent header](https://www.w3.org/TR/trace-context/#traceparent-header)
In case when between a publish and dispatch event, the context was changed ( Activity.Current ) root trace chain was broken - that's why the possibility of manual pass trace id value  was added between the publisher and dispatcher