### PR TITLE
Azure.ServiceBus nuget updated to v 7.12.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## 4.8.1
+- Changed - Azure.ServiceBus nuget updated to v 7.12.0
+
+## 4.8.0
+- Added DiagnosticID (traceparent) support for publisher / dispatcher in case of end to end tracing (according: [Distributed tracing and correlation through Service Bus messaging](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-end-to-end-tracing?tabs=net-standard-sdk-2))  
+
 ## 4.7.0
 - Added the MessageId property to the MessageContext class to allow MessageId customization on publish
 

--- a/src/Ev.ServiceBus.Abstractions/Ev.ServiceBus.Abstractions.csproj
+++ b/src/Ev.ServiceBus.Abstractions/Ev.ServiceBus.Abstractions.csproj
@@ -14,7 +14,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.5.1" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.12.0" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/Ev.ServiceBus/Ev.ServiceBus.csproj
+++ b/src/Ev.ServiceBus/Ev.ServiceBus.csproj
@@ -13,7 +13,7 @@ Its goal to is make it the easiest possible to connect and handle an Azure Servi
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.5.1" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.12.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netstandard2.0' ">


### PR DESCRIPTION
Azure.ServiceBus nuget updated to v 7.12.0 
- it will solve the issue related to Diagnostic-Id. The latest version is setting up incoming ids as a parent. Previously used added incoming Ids as a linked only. 