### PR TITLE
Fix ServiceDescriptor access for keyed services

### DIFF
--- a/src/Ev.ServiceBus/ServiceCollectionExtensions.cs
+++ b/src/Ev.ServiceBus/ServiceCollectionExtensions.cs
@@ -79,10 +79,19 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<ReceiverWrapperFactory>();
         services.TryAddSingleton<IClientFactory, ClientFactory>();
 
-        if (services.Any(o => o.ImplementationType == typeof(ServiceBusHost)) == false)
+        if (!HasImplementationType(services, typeof(ServiceBusHost)))
         {
             services.AddHostedService<ServiceBusHost>();
         }
+    }
+
+    private static bool HasImplementationType(IServiceCollection services, Type implementationType)
+    {
+        return services.Any(s =>
+#if NET8_0_OR_GREATER
+                s.ServiceKey is null &&
+#endif
+            s.ImplementationType == implementationType);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes issue where `System.InvalidOperationException: 'This service descriptor is keyed. Your service provider may not support keyed services.'` is thrown during startup if keyed services are registered.