### PR TITLE
fix issue

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## 5.1.4
+- Changed
+  - Fix diagnostic id null reference
 
 ## 5.1.3
 - Changed

--- a/src/Ev.ServiceBus.Abstractions/Extensions/DiagnosticIdExtension.cs
+++ b/src/Ev.ServiceBus.Abstractions/Extensions/DiagnosticIdExtension.cs
@@ -5,23 +5,28 @@ namespace Ev.ServiceBus.Abstractions.Extensions;
 public static class DiagnosticIdExtension
 {
     private const string DiagnosticIdKey = "Diagnostic-Id";
+
     public static string? GetDiagnosticId(this ServiceBusReceivedMessage message)
     {
-        return message.ApplicationProperties.ContainsKey(DiagnosticIdKey)
-            ? message.ApplicationProperties[DiagnosticIdKey].ToString()
-            : null;
+        if (message.ApplicationProperties.ContainsKey(DiagnosticIdKey) && message.ApplicationProperties[DiagnosticIdKey] != null)
+        {
+            return message.ApplicationProperties[DiagnosticIdKey].ToString();
+        }
+        return null;
     }
 
     public static string? GetDiagnosticId(this ServiceBusMessage message)
     {
-        return message.ApplicationProperties.ContainsKey(DiagnosticIdKey)
-            ? message.ApplicationProperties[DiagnosticIdKey].ToString()
-            : null;
+        if (message.ApplicationProperties.ContainsKey(DiagnosticIdKey) && message.ApplicationProperties[DiagnosticIdKey] != null)
+        {
+            return message.ApplicationProperties[DiagnosticIdKey].ToString();
+        }
+        return null;
     }
 
     public static void SetDiagnosticIdIfIsNot(this ServiceBusMessage message, string diagnosticId)
     {
-        if(message.ApplicationProperties.ContainsKey(DiagnosticIdKey))
+        if (message.ApplicationProperties.ContainsKey(DiagnosticIdKey) && message.ApplicationProperties[DiagnosticIdKey] != null)
             return;
         message.ApplicationProperties.Add(DiagnosticIdKey, diagnosticId);
     }


### PR DESCRIPTION
fix for the following error 
```
Exception 01 ===================================
Type: System.NullReferenceException
Source: Ev.ServiceBus.Abstractions.Extensions.DiagnosticIdExtension, Ev.ServiceBus.Abstractions, Version=5.1.3.0, Culture=neutral, PublicKeyToken=null
Message: Object reference not set to an instance of an object.
Trace:    at Ev.ServiceBus.Abstractions.Extensions.DiagnosticIdExtension.GetDiagnosticId(ServiceBusReceivedMessage message)
   at Ev.ServiceBus.Abstractions.MessageContext.ReadExecutionContext()
   at Ev.ServiceBus.ReceiverWrapper.OnMessageReceived(MessageContext context)
   at Azure.Messaging.ServiceBus.ServiceBusProcessor.OnProcessMessageAsync(ProcessMessageEventArgs args)
   at Azure.Messaging.ServiceBus.ReceiverManager.OnMessageHandler(EventArgs args)
   at Azure.Messaging.ServiceBus.ReceiverManager.ProcessOneMessage(ServiceBusReceivedMessage triggerMessage, CancellationToken cancellationToken)
Body: System.NullReferenceException: Object reference not set to an instance of an object.
   at Ev.ServiceBus.Abstractions.Extensions.DiagnosticIdExtension.GetDiagnosticId(ServiceBusReceivedMessage message)
   at Ev.ServiceBus.Abstractions.MessageContext.ReadExecutionContext()
   at Ev.ServiceBus.ReceiverWrapper.OnMessageReceived(MessageContext context)
   at Azure.Messaging.ServiceBus.ServiceBusProcessor.OnProcessMessageAsync(ProcessMessageEventArgs args)
   at Azure.Messaging.ServiceBus.ReceiverManager.OnMessageHandler(EventArgs args)
   at Azure.Messaging.ServiceBus.ReceiverManager.ProcessOneMessage(ServiceBusReceivedMessage triggerMessage, CancellationToken cancellationToken)
Location: 
Method: System.String GetDiagnosticId(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage) (0, 0)
```
Caused probably to an edge case where the dictionary does have a null value for a given key

