### PR TITLE
feat: can customize the property name that holds the payload type id in the message metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The nuget will take care of deserializing the message into proper object and giv
 
 This whole process revolves around the ability to differentiate messages by their payload types. 
 To do that, it adds a UserProperty to every message. This property is the unique identifier for a designated contract 
-across the whole system (name of the property : `PayloadTypeId`). 
+across the whole system (name of the property : `PayloadTypeId`, if you need to use another property name, please see *Customizing the PayloadTypeId property name* in [Advanced Scenarios](./docs/AdvancedScenarios.md)). 
 
 > Be careful when you have a system with several applications. If several applications send 2 different contracts 
 > with the same Id to a single queue/topic, the receiving handlers will not be able to differentiate between them.

--- a/docs/AdvancedScenarios.md
+++ b/docs/AdvancedScenarios.md
@@ -201,3 +201,29 @@ public class MyMessageSender
             }
         }
 ```
+
+
+## Customizing the PayloadTypeId property name
+
+This package uses a UserProperty attached to every message in order to differentiate them by their payload type. 
+This property is the unique identifier for a designated contract across the whole system.
+The name of the property that holds the contract name is *PayloadTypeId* by default, but there are cases where you want to change that property name.
+To send messages with a different property name you need to configure it in the receiver:
+
+```csharp
+services.RegisterServiceBusReception().FromQueue("myQueue", builder =>
+        {
+            builder.RegisterReception<Payload, MetadataHandler>();
+            builder.WithCustomPayloadTypeIdProperty("DifferentPayloadTypeIdPropertyName");
+        });
+```
+
+To receive messages with a different property name you need to configure it in the sender:
+
+```csharp
+services.RegisterServiceBusDispatch().ToQueue("myQueue", builder =>
+        {
+            builder.RegisterDispatch<PublishedEvent>()
+                .CustomizePayloadTypeIdProperty("DifferentPayloadTypeIdPropertyName");
+        });
+```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 5.3.0
+- Added
+  - Introduced *CustomizePayloadTypeIdProperty* method so we can customize the *PayloadTypeId* property name when sending to a topic or queue
+  - Introduced *WithCustomPayloadTypeIdProperty* method so we can customize the *PayloadTypeId* property name when receiving messages
+
 ## 5.2.0
 - Added
   - Introduced SendDispatch methods on DispatchSender. Those methods allow to send single message bigger than 1MB

--- a/src/Ev.ServiceBus.Abstractions/Configuration/MessageDispatchRegistration.cs
+++ b/src/Ev.ServiceBus.Abstractions/Configuration/MessageDispatchRegistration.cs
@@ -39,6 +39,8 @@ public class MessageDispatchRegistration
     /// </summary>
     public Type PayloadType { get; }
 
+    public string? PayloadTypeIdProperty { get; private set; }
+
     /// <summary>
     /// Sets the PayloadTypeId (by default it will take the <see cref="MemberInfo.Name"/> of the payload <see cref="Type"/> object)
     /// </summary>
@@ -53,6 +55,17 @@ public class MessageDispatchRegistration
         }
 
         PayloadTypeId = payloadId;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the PayloadTypeIdProperty from Metadata used to store the PayloadTypeId
+    /// </summary>
+    /// <param name="payloadTypeIdProperty"></param>
+    /// <returns></returns>
+    public MessageDispatchRegistration CustomizePayloadTypeIdProperty(string payloadTypeIdProperty)
+    {
+        PayloadTypeIdProperty = payloadTypeIdProperty;
         return this;
     }
 

--- a/src/Ev.ServiceBus.Abstractions/Configuration/ReceiverOptions.cs
+++ b/src/Ev.ServiceBus.Abstractions/Configuration/ReceiverOptions.cs
@@ -41,4 +41,11 @@ public abstract class ReceiverOptions : ClientOptions, IMessageReceiverOptions
     {
         SessionProcessorOptions = config;
     }
+
+    public string? PayloadTypeIdProperty { get; private set; }
+
+    public void WithCustomPayloadTypeIdProperty(string payloadTypeIdProperty)
+    {
+        PayloadTypeIdProperty = payloadTypeIdProperty;
+    }
 }

--- a/src/Ev.ServiceBus.Abstractions/MessageHelper.cs
+++ b/src/Ev.ServiceBus.Abstractions/MessageHelper.cs
@@ -4,9 +4,9 @@ namespace Ev.ServiceBus.Abstractions;
 
 public static class MessageHelper
 {
-    public static string? GetPayloadTypeId(this ServiceBusReceivedMessage message)
+    public static string? GetPayloadTypeId(this ServiceBusReceivedMessage message, string? payloadTypeIdProperty)
     {
-        return TryGetValue(message, UserProperties.PayloadTypeIdProperty);
+        return TryGetValue(message, payloadTypeIdProperty ?? UserProperties.DefaultPayloadTypeIdProperty);
     }
 
     private static string? TryGetValue(ServiceBusReceivedMessage message, string propertyName)
@@ -15,7 +15,7 @@ public static class MessageHelper
         return value as string;
     }
 
-    public static ServiceBusMessage CreateMessage(string contentType, byte[] body, string payloadTypeId)
+    public static ServiceBusMessage CreateMessage(string contentType, byte[] body, string payloadTypeId, string? payloadTypeIdProperty)
     {
         var message = new ServiceBusMessage(body)
         {
@@ -24,7 +24,7 @@ public static class MessageHelper
             ApplicationProperties =
             {
                 {UserProperties.MessageTypeProperty, "IntegrationEvent"},
-                {UserProperties.PayloadTypeIdProperty, payloadTypeId}
+                {payloadTypeIdProperty ?? UserProperties.DefaultPayloadTypeIdProperty, payloadTypeId}
             }
         };
         return message;

--- a/src/Ev.ServiceBus.Abstractions/MessageReception/MessageContext.cs
+++ b/src/Ev.ServiceBus.Abstractions/MessageReception/MessageContext.cs
@@ -8,24 +8,24 @@ namespace Ev.ServiceBus.Abstractions;
 
 public class MessageContext
 {
-    public MessageContext(ProcessSessionMessageEventArgs args, ClientType clientType, string resourceId)
+    public MessageContext(ProcessSessionMessageEventArgs args, ClientType clientType, string resourceId, string? payloadTypeIdProperty)
     {
         SessionArgs = args;
         ClientType = clientType;
         ResourceId = resourceId;
         Message = args.Message;
         CancellationToken = args.CancellationToken;
-        PayloadTypeId = Message.GetPayloadTypeId();
+        PayloadTypeId = Message.GetPayloadTypeId(payloadTypeIdProperty);
     }
 
-    public MessageContext(ProcessMessageEventArgs args, ClientType clientType, string resourceId)
+    public MessageContext(ProcessMessageEventArgs args, ClientType clientType, string resourceId, string? payloadTypeIdProperty)
     {
         Args = args;
         ClientType = clientType;
         ResourceId = resourceId;
         Message = args.Message;
         CancellationToken = args.CancellationToken;
-        PayloadTypeId = Message.GetPayloadTypeId();
+        PayloadTypeId = Message.GetPayloadTypeId(payloadTypeIdProperty);
     }
 
     public ServiceBusReceivedMessage Message { get; }

--- a/src/Ev.ServiceBus.Abstractions/UserProperties.cs
+++ b/src/Ev.ServiceBus.Abstractions/UserProperties.cs
@@ -5,6 +5,6 @@
 /// </summary>
 public static class UserProperties
 {
-    public const string PayloadTypeIdProperty = "PayloadTypeId";
+    public const string DefaultPayloadTypeIdProperty = "PayloadTypeId";
     public const string MessageTypeProperty = "MessageType";
 }

--- a/src/Ev.ServiceBus/Dispatch/DispatchSender.cs
+++ b/src/Ev.ServiceBus/Dispatch/DispatchSender.cs
@@ -213,9 +213,9 @@ public class DispatchSender : IDispatchSender
     {
         var originalCorrelationId = _messageMetadataAccessor.Metadata?.CorrelationId ?? Guid.NewGuid().ToString();
         var result = _messagePayloadSerializer.SerializeBody(dispatch.Payload);
-        var message = MessageHelper.CreateMessage(result.ContentType, result.Body, registration.PayloadTypeId);
+        var message = MessageHelper.CreateMessage(result.ContentType, result.Body, registration.PayloadTypeId, registration.PayloadTypeIdProperty);
 
-        dispatch.ApplicationProperties.Remove(UserProperties.PayloadTypeIdProperty);
+        dispatch.ApplicationProperties.Remove(registration.PayloadTypeIdProperty ?? UserProperties.DefaultPayloadTypeIdProperty);
         foreach (var dispatchApplicationProperty in dispatch.ApplicationProperties)
         {
             message.ApplicationProperties[dispatchApplicationProperty.Key] = dispatchApplicationProperty.Value;

--- a/src/Ev.ServiceBus/Management/Wrappers/ComposedReceiverOptions.cs
+++ b/src/Ev.ServiceBus/Management/Wrappers/ComposedReceiverOptions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Azure.Messaging.ServiceBus;
 using Ev.ServiceBus.Abstractions;
@@ -16,6 +18,7 @@ public class ComposedReceiverOptions
         SessionMode = false;
         ConnectionSettings = allOptions.First().ConnectionSettings;
         FirstOption = allOptions.First();
+        PayloadTypeIdProperty = allOptions.FirstOrDefault(o => !string.IsNullOrEmpty(o.PayloadTypeIdProperty))?.PayloadTypeIdProperty;
 
         ProcessorOptions = new ServiceBusProcessorOptions();
         foreach (var config in AllOptions.Select(o => o.ServiceBusProcessorOptions))
@@ -44,7 +47,8 @@ public class ComposedReceiverOptions
     public ServiceBusProcessorOptions ProcessorOptions { get; }
     public ServiceBusSessionProcessorOptions? SessionProcessorOptions { get; }
     public ConnectionSettings? ConnectionSettings { get; }
-
+    public string? PayloadTypeIdProperty { get; }
+    
     internal void UpdateResourceId(string resourceId)
     {
         ResourceId = resourceId;

--- a/src/Ev.ServiceBus/Management/Wrappers/ReceiverWrapper.cs
+++ b/src/Ev.ServiceBus/Management/Wrappers/ReceiverWrapper.cs
@@ -85,7 +85,7 @@ public class ReceiverWrapper
             _ => ProcessorClient
         };
         ProcessorClient!.ProcessErrorAsync += OnExceptionOccured;
-        ProcessorClient.ProcessMessageAsync += args => OnMessageReceived(new MessageContext(args, _composedOptions.ClientType, _composedOptions.ResourceId));
+        ProcessorClient.ProcessMessageAsync += args => OnMessageReceived(new MessageContext(args, _composedOptions.ClientType, _composedOptions.ResourceId, _composedOptions.PayloadTypeIdProperty));
         await ProcessorClient.StartProcessingAsync();
 
         _onExceptionReceivedHandler = _ => Task.CompletedTask;

--- a/src/Ev.ServiceBus/Management/Wrappers/SessionReceiverWrapper.cs
+++ b/src/Ev.ServiceBus/Management/Wrappers/SessionReceiverWrapper.cs
@@ -65,7 +65,7 @@ public class SessionReceiverWrapper : ReceiverWrapper
             _ => SessionProcessorClient
         };
         SessionProcessorClient!.ProcessErrorAsync += OnExceptionOccured;
-        SessionProcessorClient.ProcessMessageAsync += args => OnMessageReceived(new MessageContext(args, _composedOptions.ClientType, _composedOptions.ResourceId));
+        SessionProcessorClient.ProcessMessageAsync += args => OnMessageReceived(new MessageContext(args, _composedOptions.ClientType, _composedOptions.ResourceId, _composedOptions.PayloadTypeIdProperty));
         await SessionProcessorClient.StartProcessingAsync();
 
         _onExceptionReceivedHandler = _ => Task.CompletedTask;

--- a/src/Ev.ServiceBus/Reception/ReceptionRegistrationBuilder.cs
+++ b/src/Ev.ServiceBus/Reception/ReceptionRegistrationBuilder.cs
@@ -94,4 +94,13 @@ public class ReceptionRegistrationBuilder
     {
         _options.EnableSessionHandling(config);
     }
+
+    /// <summary>
+    /// Overrides the default property name for PayloadTypeId key in metadata.
+    /// </summary>
+    /// <param name="customPayloadTypeIdProperty"></param>
+    public void WithCustomPayloadTypeIdProperty(string customPayloadTypeIdProperty)
+    {
+        _options.WithCustomPayloadTypeIdProperty(customPayloadTypeIdProperty);
+    }
 }

--- a/tests/Ev.ServiceBus.TestHelpers/TestMessageHelper.cs
+++ b/tests/Ev.ServiceBus.TestHelpers/TestMessageHelper.cs
@@ -6,11 +6,11 @@ namespace Ev.ServiceBus.TestHelpers;
 
 public static class TestMessageHelper
 {
-    public static ServiceBusMessage CreateEventMessage(string payloadTypeId, object payload)
+    public static ServiceBusMessage CreateEventMessage(string payloadTypeId, object payload, string payloadTypeIdProperty = UserProperties.DefaultPayloadTypeIdProperty)
     {
         var parser = new TextJsonPayloadSerializer();
         var result = parser.SerializeBody(payload);
-        var message = MessageHelper.CreateMessage(result.ContentType, result.Body, payloadTypeId);
+        var message = MessageHelper.CreateMessage(result.ContentType, result.Body, payloadTypeId, payloadTypeIdProperty);
 
         return message;
     }

--- a/tests/Ev.ServiceBus.UnitTests/EventListenerTests.cs
+++ b/tests/Ev.ServiceBus.UnitTests/EventListenerTests.cs
@@ -14,8 +14,10 @@ namespace Ev.ServiceBus.UnitTests;
 
 public class EventListenerTests
 {
-    [Fact]
-    public async Task CanListenToQueueEvents()
+    [Theory]
+    [InlineData(null)]
+    [InlineData("customPropertyName")]
+    public async Task CanListenToQueueEvents(string customPropertyName)
     {
         var mock = new Mock<IServiceBusEventListener>();
         var composer = new Composer();
@@ -31,6 +33,7 @@ public class EventListenerTests
             services.RegisterServiceBusReception().FromQueue("testQueue", builder =>
             {
                 builder.RegisterReception<SubscribedEvent, SubscribedEventHandler>();
+                builder.WithCustomPayloadTypeIdProperty(customPropertyName);
             });
 
         });
@@ -38,7 +41,7 @@ public class EventListenerTests
 
         var clientMock = composer.Provider.GetProcessorMock("testQueue");
         var result = composer.Provider.GetRequiredService<IMessagePayloadSerializer>().SerializeBody(new SubscribedEvent());
-        var message = MessageHelper.CreateMessage(result.ContentType, result.Body, nameof(SubscribedEvent));
+        var message = MessageHelper.CreateMessage(result.ContentType, result.Body, nameof(SubscribedEvent), customPropertyName);
 
         await clientMock.TriggerMessageReception(message, CancellationToken.None);
 
@@ -71,7 +74,7 @@ public class EventListenerTests
 
         var clientMock = composer.Provider.GetProcessorMock("testQueue");
         var result = composer.Provider.GetRequiredService<IMessagePayloadSerializer>().SerializeBody(new SubscribedEvent());
-        var message = MessageHelper.CreateMessage(result.ContentType, result.Body, nameof(SubscribedEvent));
+        var message = MessageHelper.CreateMessage(result.ContentType, result.Body, nameof(SubscribedEvent), null);
         message.MessageId = Guid.NewGuid().ToString();
 
         var action = async () =>
@@ -119,7 +122,7 @@ public class EventListenerTests
 
         var clientMock = composer.Provider.GetProcessorMock("testTopic", "testSubscription");
         var result = composer.Provider.GetRequiredService<IMessagePayloadSerializer>().SerializeBody(new SubscribedEvent());
-        var message = MessageHelper.CreateMessage(result.ContentType, result.Body, nameof(SubscribedEvent));
+        var message = MessageHelper.CreateMessage(result.ContentType, result.Body, nameof(SubscribedEvent), null);
 
         await clientMock.TriggerMessageReception(message, CancellationToken.None);
 
@@ -152,7 +155,7 @@ public class EventListenerTests
 
         var clientMock = composer.Provider.GetProcessorMock("testTopic", "testSubscription");
         var result = composer.Provider.GetRequiredService<IMessagePayloadSerializer>().SerializeBody(new SubscribedEvent());
-        var message = MessageHelper.CreateMessage(result.ContentType, result.Body, nameof(SubscribedEvent));
+        var message = MessageHelper.CreateMessage(result.ContentType, result.Body, nameof(SubscribedEvent), null);
         message.MessageId = Guid.NewGuid().ToString();
 
         var action = async () =>

--- a/tests/Ev.ServiceBus.UnitTests/ReceptionTest.cs
+++ b/tests/Ev.ServiceBus.UnitTests/ReceptionTest.cs
@@ -309,7 +309,7 @@ public class ReceptionTest
             ApplicationProperties =
             {
                 { UserProperties.MessageTypeProperty, "IntegrationEvent" },
-                { UserProperties.PayloadTypeIdProperty, "MyEvent" }
+                { UserProperties.DefaultPayloadTypeIdProperty, "MyEvent" }
             }
         };
 


### PR DESCRIPTION
We didn't want to have two fields with the same information in our messages, so in order to use Ev.ServiceBus library in a new project we needed to customize the property that has the PayloadTypeId in the message's metadata to fit the name we are using in our current system.
This PR allows to customize the property name to be something other that "PayloadTypeId". 