### PR TITLE
Enable backward compatibility by enabling empty isolation key

### DIFF
--- a/src/Ev.ServiceBus.Abstractions/Configuration/ServiceBusSettings.cs
+++ b/src/Ev.ServiceBus.Abstractions/Configuration/ServiceBusSettings.cs
@@ -28,7 +28,7 @@ public sealed class ServiceBusSettings
     /// </summary>
     public bool UseIsolation { get; set; } = false;
     /// <summary>
-    /// Key that is used to deremine if this running instance should receive and complete or abandon a message
+    /// Key that is used to determine if this running instance should receive and complete or abandon a message
     /// </summary>
     public string? IsolationKey { get; set; } = null;
 

--- a/src/Ev.ServiceBus/Reception/MessageReceptionHandler.cs
+++ b/src/Ev.ServiceBus/Reception/MessageReceptionHandler.cs
@@ -50,7 +50,7 @@ public class MessageReceptionHandler
             if (_serviceBusOptions.Settings.UseIsolation)
             {
                 var expectedIsolationKey = _serviceBusOptions.Settings.IsolationKey;
-                var receivedIsolationKey = context.IsolationKey;
+                var receivedIsolationKey = context.IsolationKey ?? string.Empty;
                 if (receivedIsolationKey != expectedIsolationKey)
                 {
                     _logger.IgnoreMessage(expectedIsolationKey, receivedIsolationKey);

--- a/src/Ev.ServiceBus/ServiceBusEngine.cs
+++ b/src/Ev.ServiceBus/ServiceBusEngine.cs
@@ -51,7 +51,7 @@ public class ServiceBusEngine
                 _serviceBusEngineLogger.FailedToConnectToServiceBus(ex);
             }
         }
-        if (settings.UseIsolation && string.IsNullOrEmpty(settings.IsolationKey))
+        if (settings.UseIsolation && settings.IsolationKey == null)
         {
             throw new Exception("Isolation key must be set when isolation is enabled");
         }


### PR DESCRIPTION
Enable running Service Bus engine with isolation key as empty string. Empty string is also used when there is no custom property that comes to message reception handler.
Both of these changes make sure that we can both:
- process messages that comes from microservices that do not use Ev.ServiceBus (or are not migrated to version with isolation)
- local instances of microservices do not consume messages with no isolation key custom property