### PR TITLE
Change the connection string parser inside the ConnectionSettings class to prevent reinventing the wheel

### DIFF
--- a/src/Ev.ServiceBus.Abstractions/Configuration/ClientOptions.cs
+++ b/src/Ev.ServiceBus.Abstractions/Configuration/ClientOptions.cs
@@ -1,5 +1,7 @@
 ﻿// ReSharper disable once CheckNamespace
 
+using Ev.ServiceBus.Abstractions.Configuration;
+
 namespace Ev.ServiceBus.Abstractions;
 
 public abstract class ClientOptions : IClientOptions

--- a/src/Ev.ServiceBus.Abstractions/Configuration/ConnectionSettings.cs
+++ b/src/Ev.ServiceBus.Abstractions/Configuration/ConnectionSettings.cs
@@ -8,6 +8,11 @@ public class ConnectionSettings
 {
     internal ConnectionSettings(string connectionString, ServiceBusClientOptions options, TokenCredential? credentials = null)
     {
+        if (!connectionString.StartsWith("Endpoint=", StringComparison.OrdinalIgnoreCase))
+        {
+            connectionString = $"Endpoint={connectionString}";
+        }
+
         var connectionStringProperties = ServiceBusConnectionStringProperties.Parse(connectionString);
 
         ConnectionString = connectionString;

--- a/src/Ev.ServiceBus.Abstractions/Configuration/ConnectionSettings.cs
+++ b/src/Ev.ServiceBus.Abstractions/Configuration/ConnectionSettings.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using Azure.Messaging.ServiceBus;
+﻿using Azure.Messaging.ServiceBus;
 
-namespace Ev.ServiceBus.Abstractions;
+namespace Ev.ServiceBus.Abstractions.Configuration;
 
 public class ConnectionSettings
 {
@@ -9,39 +8,12 @@ public class ConnectionSettings
     {
         ConnectionString = connectionString;
         Options = options;
-        Endpoint = GetEndpointFromConnectionString(connectionString);
+        Endpoint = ServiceBusConnectionStringProperties.Parse(connectionString).Endpoint.AbsoluteUri;
     }
 
     public string Endpoint { get; }
     public string ConnectionString { get; }
     public ServiceBusClientOptions Options { get; }
-
-    private string GetEndpointFromConnectionString(string connectionString)
-    {
-        var KeyValuePairDelimiter = ';';
-        var KeyValueSeparator = '=';
-        var EndpointConfigName = "Endpoint";
-
-        // First split based on ';'
-        var keyValuePairs = connectionString.Split(new[] { KeyValuePairDelimiter }, StringSplitOptions.RemoveEmptyEntries);
-        foreach (var keyValuePair in keyValuePairs)
-        {
-            // Now split based on the _first_ '='
-            var keyAndValue = keyValuePair.Split(new[] { KeyValueSeparator }, 2);
-            var key = keyAndValue[0];
-            if (keyAndValue.Length != 2)
-            {
-                return string.Empty;
-            }
-
-            var value = keyAndValue[1].Trim();
-            if (key.Equals(EndpointConfigName, StringComparison.OrdinalIgnoreCase))
-            {
-                return value;
-            }
-        }
-        return string.Empty;
-    }
 
     public override int GetHashCode()
     {
@@ -50,10 +22,6 @@ public class ConnectionSettings
 
     public override bool Equals(object? obj)
     {
-        if (obj is not ConnectionSettings settings)
-        {
-            return false;
-        }
-        return Endpoint.Equals(settings.Endpoint);
+        return obj is ConnectionSettings settings && Endpoint.Equals(settings.Endpoint);
     }
 }

--- a/src/Ev.ServiceBus.Abstractions/Configuration/ConnectionSettings.cs
+++ b/src/Ev.ServiceBus.Abstractions/Configuration/ConnectionSettings.cs
@@ -6,19 +6,15 @@ namespace Ev.ServiceBus.Abstractions.Configuration;
 
 public class ConnectionSettings
 {
-    internal ConnectionSettings(string connectionString, ServiceBusClientOptions options)
+    internal ConnectionSettings(string connectionString, ServiceBusClientOptions options, TokenCredential? credentials = null)
     {
         ConnectionString = connectionString;
         Options = options;
         Endpoint = ServiceBusConnectionStringProperties.Parse(connectionString).Endpoint.AbsoluteUri;
-    }
-
-    internal ConnectionSettings(string fullyQualifiedNamespace, TokenCredential credentials, ServiceBusClientOptions options)
-    {
-        Options = options;
-        FullyQualifiedNamespace = fullyQualifiedNamespace;
+        FullyQualifiedNamespace = credentials == null
+            ? null
+            : ServiceBusConnectionStringProperties.Parse(connectionString).FullyQualifiedNamespace;
         Credentials = credentials;
-        Endpoint = ServiceBusConnectionStringProperties.Parse(fullyQualifiedNamespace).Endpoint.AbsoluteUri;
     }
 
     public string Endpoint { get; }

--- a/src/Ev.ServiceBus.Abstractions/Configuration/ConnectionSettings.cs
+++ b/src/Ev.ServiceBus.Abstractions/Configuration/ConnectionSettings.cs
@@ -6,20 +6,26 @@ namespace Ev.ServiceBus.Abstractions.Configuration;
 
 public class ConnectionSettings
 {
-    internal ConnectionSettings(string connectionString, ServiceBusClientOptions options, TokenCredential? credentials = null)
+    internal ConnectionSettings(string connectionString, ServiceBusClientOptions options)
     {
-        if (!connectionString.StartsWith("Endpoint=", StringComparison.OrdinalIgnoreCase))
-        {
-            connectionString = $"Endpoint={connectionString}";
-        }
-
-        var connectionStringProperties = ServiceBusConnectionStringProperties.Parse(connectionString);
-
         ConnectionString = connectionString;
         Options = options;
-        Endpoint = connectionStringProperties.Endpoint.AbsoluteUri;
-        FullyQualifiedNamespace = credentials == null ? null : connectionStringProperties.FullyQualifiedNamespace;
+        Endpoint = ServiceBusConnectionStringProperties.Parse(connectionString).Endpoint.AbsoluteUri;
+    }
+
+    internal ConnectionSettings(string fullyQualifiedNamespace, TokenCredential credentials, ServiceBusClientOptions options)
+    {
+        if (!fullyQualifiedNamespace.StartsWith("Endpoint=", StringComparison.OrdinalIgnoreCase))
+        {
+            fullyQualifiedNamespace = $"Endpoint={fullyQualifiedNamespace}";
+        }
+
+        var connectionStringProperties = ServiceBusConnectionStringProperties.Parse(fullyQualifiedNamespace);
+
+        Options = options;
+        FullyQualifiedNamespace = connectionStringProperties.FullyQualifiedNamespace;
         Credentials = credentials;
+        Endpoint = connectionStringProperties.Endpoint.AbsoluteUri;
     }
 
     public string Endpoint { get; }

--- a/src/Ev.ServiceBus.Abstractions/Configuration/ConnectionSettings.cs
+++ b/src/Ev.ServiceBus.Abstractions/Configuration/ConnectionSettings.cs
@@ -8,12 +8,12 @@ public class ConnectionSettings
 {
     internal ConnectionSettings(string connectionString, ServiceBusClientOptions options, TokenCredential? credentials = null)
     {
+        var connectionStringProperties = ServiceBusConnectionStringProperties.Parse(connectionString);
+
         ConnectionString = connectionString;
         Options = options;
-        Endpoint = ServiceBusConnectionStringProperties.Parse(connectionString).Endpoint.AbsoluteUri;
-        FullyQualifiedNamespace = credentials == null
-            ? null
-            : ServiceBusConnectionStringProperties.Parse(connectionString).FullyQualifiedNamespace;
+        Endpoint = connectionStringProperties.Endpoint.AbsoluteUri;
+        FullyQualifiedNamespace = credentials == null ? null : connectionStringProperties.FullyQualifiedNamespace;
         Credentials = credentials;
     }
 

--- a/src/Ev.ServiceBus.Abstractions/Configuration/Extensions/ClientOptionsExtensions.cs
+++ b/src/Ev.ServiceBus.Abstractions/Configuration/Extensions/ClientOptionsExtensions.cs
@@ -43,7 +43,7 @@ public static class ClientOptionsExtensions
         ServiceBusClientOptions connectionOptions)
         where TOptions : ClientOptions
     {
-        options.ConnectionSettings = new ConnectionSettings(fullyQualifiedNamespace, credentials, connectionOptions);
+        options.ConnectionSettings = new ConnectionSettings(fullyQualifiedNamespace, connectionOptions, credentials);
         return options;
     }
 }

--- a/src/Ev.ServiceBus.Abstractions/Configuration/Extensions/ClientOptionsExtensions.cs
+++ b/src/Ev.ServiceBus.Abstractions/Configuration/Extensions/ClientOptionsExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Azure.Messaging.ServiceBus;
+using Ev.ServiceBus.Abstractions.Configuration;
 
 // ReSharper disable once CheckNamespace
 namespace Ev.ServiceBus.Abstractions;

--- a/src/Ev.ServiceBus.Abstractions/Configuration/Extensions/ClientOptionsExtensions.cs
+++ b/src/Ev.ServiceBus.Abstractions/Configuration/Extensions/ClientOptionsExtensions.cs
@@ -43,7 +43,7 @@ public static class ClientOptionsExtensions
         ServiceBusClientOptions connectionOptions)
         where TOptions : ClientOptions
     {
-        options.ConnectionSettings = new ConnectionSettings(fullyQualifiedNamespace, connectionOptions, credentials);
+        options.ConnectionSettings = new ConnectionSettings(fullyQualifiedNamespace, credentials, connectionOptions);
         return options;
     }
 }

--- a/src/Ev.ServiceBus.Abstractions/Configuration/IClientOptions.cs
+++ b/src/Ev.ServiceBus.Abstractions/Configuration/IClientOptions.cs
@@ -1,4 +1,7 @@
 ﻿// ReSharper disable once CheckNamespace
+
+using Ev.ServiceBus.Abstractions.Configuration;
+
 namespace Ev.ServiceBus.Abstractions;
 
 public interface IClientOptions

--- a/src/Ev.ServiceBus.Abstractions/Configuration/ServiceBusSettings.cs
+++ b/src/Ev.ServiceBus.Abstractions/Configuration/ServiceBusSettings.cs
@@ -39,7 +39,7 @@ public sealed class ServiceBusSettings
 
     public void WithConnection(string fullyQualifiedNamespace, TokenCredential tokenCredential, ServiceBusClientOptions options)
     {
-        ConnectionSettings = new ConnectionSettings(fullyQualifiedNamespace, options, tokenCredential);
+        ConnectionSettings = new ConnectionSettings(fullyQualifiedNamespace, tokenCredential, options);
     }
 
     public void WithIsolation(IsolationBehavior behavior, string? isolationKey = null, string? applicationName = null)

--- a/src/Ev.ServiceBus.Abstractions/Configuration/ServiceBusSettings.cs
+++ b/src/Ev.ServiceBus.Abstractions/Configuration/ServiceBusSettings.cs
@@ -1,4 +1,5 @@
 ﻿using Azure.Messaging.ServiceBus;
+using Ev.ServiceBus.Abstractions.Configuration;
 
 namespace Ev.ServiceBus.Abstractions;
 

--- a/src/Ev.ServiceBus.Abstractions/Configuration/ServiceBusSettings.cs
+++ b/src/Ev.ServiceBus.Abstractions/Configuration/ServiceBusSettings.cs
@@ -39,7 +39,7 @@ public sealed class ServiceBusSettings
 
     public void WithConnection(string fullyQualifiedNamespace, TokenCredential tokenCredential, ServiceBusClientOptions options)
     {
-        ConnectionSettings = new ConnectionSettings(fullyQualifiedNamespace, tokenCredential, options);
+        ConnectionSettings = new ConnectionSettings(fullyQualifiedNamespace, options, tokenCredential);
     }
 
     public void WithIsolation(IsolationBehavior behavior, string? isolationKey = null, string? applicationName = null)

--- a/src/Ev.ServiceBus.AsyncApi/DocumentFilter.cs
+++ b/src/Ev.ServiceBus.AsyncApi/DocumentFilter.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Encodings.Web;
-using System.Text.Json;
 using Ev.ServiceBus.Abstractions;
+using Ev.ServiceBus.Abstractions.Configuration;
 using Microsoft.Extensions.Options;
-using Microsoft.VisualBasic;
 using NJsonSchema;
 using Saunter.AsyncApiSchema.v2;
 using Saunter.AsyncApiSchema.v2.Bindings;
@@ -117,7 +115,7 @@ public class DocumentFilter : IDocumentFilter
 
     private IMessage GenerateMessage(string payloadTypeId, Type payloadType, DocumentFilterContext context, AsyncApiSchemaResolver asyncApiSchemaResolver)
     {
-        var message = new Saunter.AsyncApiSchema.v2.Message()
+        var message = new Message()
         {
             Name = payloadTypeId.Replace("/", "¤"),
             Payload = GetOrCreatePayloadSchema(payloadType, context),

--- a/src/Ev.ServiceBus.HealthChecks/ConnectionSettingsComparer.cs
+++ b/src/Ev.ServiceBus.HealthChecks/ConnectionSettingsComparer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Ev.ServiceBus.Abstractions.Configuration;
 
 namespace Ev.ServiceBus.HealthChecks;

--- a/src/Ev.ServiceBus.HealthChecks/ConnectionSettingsComparer.cs
+++ b/src/Ev.ServiceBus.HealthChecks/ConnectionSettingsComparer.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using Ev.ServiceBus.Abstractions;
+﻿using System.Collections.Generic;
+using Ev.ServiceBus.Abstractions.Configuration;
 
 namespace Ev.ServiceBus.HealthChecks;
 

--- a/src/Ev.ServiceBus/Management/Factories/ClientFactory.cs
+++ b/src/Ev.ServiceBus/Management/Factories/ClientFactory.cs
@@ -1,5 +1,5 @@
 using Azure.Messaging.ServiceBus;
-using Ev.ServiceBus.Abstractions;
+using Ev.ServiceBus.Abstractions.Configuration;
 
 namespace Ev.ServiceBus;
 

--- a/src/Ev.ServiceBus/Management/Factories/IClientFactory.cs
+++ b/src/Ev.ServiceBus/Management/Factories/IClientFactory.cs
@@ -1,5 +1,5 @@
 ﻿using Azure.Messaging.ServiceBus;
-using Ev.ServiceBus.Abstractions;
+using Ev.ServiceBus.Abstractions.Configuration;
 
 // ReSharper disable once CheckNamespace
 namespace Ev.ServiceBus;

--- a/src/Ev.ServiceBus/Management/ServiceBusRegistry.cs
+++ b/src/Ev.ServiceBus/Management/ServiceBusRegistry.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Azure.Messaging.ServiceBus;
 using Ev.ServiceBus.Abstractions;
+using Ev.ServiceBus.Abstractions.Configuration;
 using Microsoft.Extensions.Options;
 
 namespace Ev.ServiceBus.Management;

--- a/src/Ev.ServiceBus/Management/Wrappers/ComposedReceiverOptions.cs
+++ b/src/Ev.ServiceBus/Management/Wrappers/ComposedReceiverOptions.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Azure.Messaging.ServiceBus;
 using Ev.ServiceBus.Abstractions;
+using Ev.ServiceBus.Abstractions.Configuration;
 
 namespace Ev.ServiceBus;
 

--- a/tests/Ev.ServiceBus.HealthChecks.UnitTests/ComplexTest.cs
+++ b/tests/Ev.ServiceBus.HealthChecks.UnitTests/ComplexTest.cs
@@ -174,7 +174,7 @@ public class ComplexTest
 
         services.AddServiceBus(settings =>
         {
-            settings.WithConnection("Endpoint=acmecompany.servicebus.windows.net", new DefaultAzureCredential(), new ServiceBusClientOptions());
+            settings.WithConnection("acmecompany.servicebus.windows.net", new DefaultAzureCredential(), new ServiceBusClientOptions());
         });
 
         services.AddHealthChecks().AddEvServiceBusChecks();

--- a/tests/Ev.ServiceBus.HealthChecks.UnitTests/ComplexTest.cs
+++ b/tests/Ev.ServiceBus.HealthChecks.UnitTests/ComplexTest.cs
@@ -138,7 +138,7 @@ public class ComplexTest
 
         services.AddServiceBus(settings =>
         {
-            settings.WithConnection("Endpoint=testConnectionString;", new ServiceBusClientOptions());
+            settings.WithConnection("Endpoint=acmecompany.servicebus.windows.net;", new ServiceBusClientOptions());
         });
 
         services.AddHealthChecks().AddEvServiceBusChecks();
@@ -174,7 +174,7 @@ public class ComplexTest
 
         services.AddServiceBus(settings =>
         {
-            settings.WithConnection("fullyQualifiedNamespace", new DefaultAzureCredential(), new ServiceBusClientOptions());
+            settings.WithConnection("Endpoint=acmecompany.servicebus.windows.net", new DefaultAzureCredential(), new ServiceBusClientOptions());
         });
 
         services.AddHealthChecks().AddEvServiceBusChecks();

--- a/tests/Ev.ServiceBus.TestHelpers/FailingClientFactory.cs
+++ b/tests/Ev.ServiceBus.TestHelpers/FailingClientFactory.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Azure.Messaging.ServiceBus;
-using Ev.ServiceBus.Abstractions;
+using Ev.ServiceBus.Abstractions.Configuration;
 
 namespace Ev.ServiceBus.UnitTests.Helpers;
 

--- a/tests/Ev.ServiceBus.TestHelpers/FakeClientFactory.cs
+++ b/tests/Ev.ServiceBus.TestHelpers/FakeClientFactory.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Azure.Messaging.ServiceBus;
-using Ev.ServiceBus.Abstractions;
+using Ev.ServiceBus.Abstractions.Configuration;
 
 namespace Ev.ServiceBus.TestHelpers;
 

--- a/tests/Ev.ServiceBus.TestHelpers/ServiceBusClientMock.cs
+++ b/tests/Ev.ServiceBus.TestHelpers/ServiceBusClientMock.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Azure.Messaging.ServiceBus;
-using Ev.ServiceBus.Abstractions;
+using Ev.ServiceBus.Abstractions.Configuration;
 using Moq;
 
 namespace Ev.ServiceBus.TestHelpers;

--- a/tests/Ev.ServiceBus.UnitTests/Configuration/ReceptionConfigurationTest.cs
+++ b/tests/Ev.ServiceBus.UnitTests/Configuration/ReceptionConfigurationTest.cs
@@ -357,6 +357,7 @@ public class ReceptionConfigurationTest
     [Fact]
     public async Task CustomizeConnection_ChangesAreAppliedToClient()
     {
+        const string connectionString = "Endpoint=sb://acmecompany.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=kFCrVU8u5v0LASbKGA3MHDpnCOguiNwL++r1cAvblhc=";
         var composer = new Composer();
 
         composer.WithAdditionalServices(services =>
@@ -365,7 +366,7 @@ public class ReceptionConfigurationTest
                 .FromSubscription("testTopic", "testSubscription",
                     builder =>
                     {
-                        builder.CustomizeConnection("Endpoint=newConnectionString;", new ServiceBusClientOptions()
+                        builder.CustomizeConnection(connectionString, new ServiceBusClientOptions
                         {
                             EnableCrossEntityTransactions = true,
                             TransportType = ServiceBusTransportType.AmqpWebSockets
@@ -376,7 +377,7 @@ public class ReceptionConfigurationTest
         });
 
         await composer.Compose();
-        var client = composer.ClientFactory.GetAssociatedMock("newConnectionString");
+        var client = composer.ClientFactory.GetAssociatedMock("sb://acmecompany.servicebus.windows.net/");
         client.ConnectionSettings.Options.EnableCrossEntityTransactions.Should().Be(true);
         client.ConnectionSettings.Options.TransportType.Should().Be(ServiceBusTransportType.AmqpWebSockets);
     }

--- a/tests/Ev.ServiceBus.UnitTests/Configuration/ServiceBusSettingsTests.cs
+++ b/tests/Ev.ServiceBus.UnitTests/Configuration/ServiceBusSettingsTests.cs
@@ -29,18 +29,19 @@ public class ServiceBusSettingsTests
     [Fact]
     public async Task ServiceBusSettingsStateAfterCallOfWithConnection_string()
     {
+        const string connectionString = "Endpoint=sb://acmecompany.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=kFCrVU8u5v0LASbKGA3MHDpnCOguiNwL++r1cAvblhc=";
         var composer = new Composer();
 
         composer.WithDefaultSettings(
             settings =>
             {
-                settings.WithConnection("Endpoint=testConnectionString;", new ServiceBusClientOptions());
+                settings.WithConnection(connectionString, new ServiceBusClientOptions());
             });
         var provider = await composer.Compose();
 
         var options = provider.GetService<IOptions<ServiceBusOptions>>();
 
         options.Value.Settings.ConnectionSettings.Should().NotBeNull();
-        options.Value.Settings.ConnectionSettings!.Endpoint.Should().Be("testConnectionString");
+        options.Value.Settings.ConnectionSettings!.Endpoint.Should().Be("sb://acmecompany.servicebus.windows.net/");
     }
 }

--- a/tests/Ev.ServiceBus.UnitTests/DispatchTest.cs
+++ b/tests/Ev.ServiceBus.UnitTests/DispatchTest.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -408,10 +407,11 @@ public class DispatchTest : IDisposable
     public async Task SendDispatch()
     {
         // configure
+        const string connectionString = "Endpoint=sb://acmecompany.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=kFCrVU8u5v0LASbKGA3MHDpnCOguiNwL++r1cAvblhc=";
         var services = new ServiceCollection();
         services.AddServiceBus(settings =>
         {
-            settings.WithConnection("myConnection", new ServiceBusClientOptions());
+            settings.WithConnection(connectionString, new ServiceBusClientOptions());
         });
         services.OverrideClientFactory();
         services.RegisterServiceBusDispatch().ToQueue("myQueue", builder =>
@@ -447,10 +447,11 @@ public class DispatchTest : IDisposable
     public async Task SendDispatchesPaginateMessages()
     {
         // configure
+        const string connectionString = "Endpoint=sb://acmecompany.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=kFCrVU8u5v0LASbKGA3MHDpnCOguiNwL++r1cAvblhc=";
         var services = new ServiceCollection();
         services.AddServiceBus(settings =>
         {
-            settings.WithConnection("myConnection", new ServiceBusClientOptions());
+            settings.WithConnection(connectionString, new ServiceBusClientOptions());
         });
         services.OverrideClientFactory();
         services.RegisterServiceBusDispatch().ToQueue("myQueue", builder =>
@@ -458,14 +459,14 @@ public class DispatchTest : IDisposable
             builder.RegisterDispatch<SubscribedEvent>();
         });
         var provider = services.BuildServiceProvider();
-        await provider.SimulateStartHost(new CancellationToken());
+        await provider.SimulateStartHost(CancellationToken.None);
 
         // Act
         var messages = new SubscribedEvent[10000];
         int i = 0;
         while (i < 10000)
         {
-            messages[i] = new SubscribedEvent()
+            messages[i] = new SubscribedEvent
             {
                 SomeNumber = i + 1,
                 SomeString = $"Event number {i+1}"
@@ -484,17 +485,18 @@ public class DispatchTest : IDisposable
         mock.Mock.Verify(o => o.SendMessagesAsync(It.IsAny<ServiceBusMessageBatch>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
 
         // Dispose
-        await provider.SimulateStopHost(new CancellationToken());
+        await provider.SimulateStopHost(CancellationToken.None);
     }
 
     [Fact]
     public async Task ScheduleDispatchesPaginateMessages()
     {
         // configure
+        const string connectionString = "Endpoint=sb://acmecompany.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=kFCrVU8u5v0LASbKGA3MHDpnCOguiNwL++r1cAvblhc=";
         var services = new ServiceCollection();
         services.AddServiceBus(settings =>
         {
-            settings.WithConnection("myConnection", new ServiceBusClientOptions());
+            settings.WithConnection(connectionString, new ServiceBusClientOptions());
         });
         services.OverrideClientFactory();
         services.RegisterServiceBusDispatch().ToQueue("myQueue", builder =>
@@ -502,14 +504,14 @@ public class DispatchTest : IDisposable
             builder.RegisterDispatch<SubscribedEvent>();
         });
         var provider = services.BuildServiceProvider();
-        await provider.SimulateStartHost(new CancellationToken());
+        await provider.SimulateStartHost(CancellationToken.None);
 
         // Act
         var messages = new SubscribedEvent[253];
         int i = 0;
         while (i < 253)
         {
-            messages[i] = new SubscribedEvent()
+            messages[i] = new SubscribedEvent
             {
                 SomeNumber = i + 1,
                 SomeString = $"Event number {i+1}"
@@ -530,7 +532,7 @@ public class DispatchTest : IDisposable
         mock.Mock.Verify(o => o.ScheduleMessagesAsync(It.IsAny<IEnumerable<ServiceBusMessage>>(), schedule, It.IsAny<CancellationToken>()), Times.Exactly(3));
 
         // Dispose
-        await provider.SimulateStopHost(new CancellationToken());
+        await provider.SimulateStopHost(CancellationToken.None);
     }
 
     [Fact]


### PR DESCRIPTION
This change improves code quality and maintainability by replacing a custom connection string parser with the official Azure SDK implementation `ServiceBusConnectionStringProperties.Parse()`.

Why? The Azure SDK parser is thoroughly tested by **Microsoft** and handles all edge cases, encoding issues, and future connection string format changes automatically. No need to maintain custom parsing logic. Updates to connection string format will be handled by SDK updates.

Unit test now uses proper fake connection string.

I also moved the class to the `Ev.ServiceBus.Abstractions.Configuration` namespace.

**UPDATE:**
I don't think we need to use the absolute URI (sb://\<URL\>/) to connect to Microsoft Entra ID. We only need the fully qualified name (FQN).
Source: [Authenticate a managed identity with Microsoft Entra ID to access Azure Service Bus resources](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-managed-service-identity#:~:text=a%20string%2C%20for%20example%3A%20cotosons.servicebus.windows.net)