### PR TITLE
Prevent dispatch when Service Bus is disabled

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.6.1
+- fixed
+  - Fixed an issue with dispatching messages when the Enabled flag is set to false.
+
 ## 5.6.0
 - Added
   - netstandard2.0 target framework.

--- a/src/Ev.ServiceBus/Dispatch/DispatchSender.cs
+++ b/src/Ev.ServiceBus/Dispatch/DispatchSender.cs
@@ -42,6 +42,8 @@ public class DispatchSender : IDispatchSender
     /// <inheritdoc />
     public async Task SendDispatch(object messagePayload, CancellationToken token = default)
     {
+        if (IsDisabled()) return;
+
         var dispatch = new Abstractions.Dispatch(messagePayload);
 
         await SendDispatch(dispatch, token);
@@ -50,6 +52,8 @@ public class DispatchSender : IDispatchSender
     /// <inheritdoc />
     public async Task SendDispatch(Abstractions.Dispatch messagePayload, CancellationToken token = default)
     {
+        if (IsDisabled()) return;
+
         var dispatches = CreateMessagesToSend([messagePayload]);
 
         foreach (var messagePerResource in dispatches)
@@ -74,6 +78,8 @@ public class DispatchSender : IDispatchSender
             throw new ArgumentNullException(nameof(messagePayloads));
         }
 
+        if (IsDisabled()) return;
+
         var dispatches = messagePayloads.Select(o => new Abstractions.Dispatch(o)).ToArray();
         await SendDispatches(dispatches, token);
     }
@@ -85,6 +91,8 @@ public class DispatchSender : IDispatchSender
         {
             throw new ArgumentNullException(nameof(messagePayloads));
         }
+
+        if (IsDisabled()) return;
 
         var dispatches = CreateMessagesToSend(messagePayloads);
         foreach (var messagesPerResource in dispatches)
@@ -139,6 +147,8 @@ public class DispatchSender : IDispatchSender
             throw new ArgumentNullException(nameof(messagePayloads));
         }
 
+        if (IsDisabled()) return;
+
         var dispatches = messagePayloads.Select(o => new Abstractions.Dispatch(o)).ToArray();
         await ScheduleDispatches(dispatches, scheduledEnqueueTime, token);
     }
@@ -150,6 +160,8 @@ public class DispatchSender : IDispatchSender
         {
             throw new ArgumentNullException(nameof(messagePayloads));
         }
+
+        if (IsDisabled()) return;
 
         var dispatches = CreateMessagesToSend(messagePayloads);
         foreach (var messagesPerResource in dispatches)
@@ -279,4 +291,6 @@ public class DispatchSender : IDispatchSender
         }
         return message;
     }
+
+    private bool IsDisabled() => _serviceBusOptions.Settings.Enabled == false;
 }

--- a/tests/Ev.ServiceBus.UnitTests/DispatchTest.cs
+++ b/tests/Ev.ServiceBus.UnitTests/DispatchTest.cs
@@ -582,6 +582,159 @@ public class DispatchTest : IDisposable
         _sentMessagesToQueue[0].ApplicationProperties.GetIsolationKey().Should().Be(isolationKey);
     }
 
+    [Fact]
+    public async Task SendDispatch_Object_WhenDisabled_DoesNotInvokeSender()
+    {
+        var provider = await CreateDisabledProviderAsync();
+
+        using (var scope = provider.CreateScope())
+        {
+            var sender = scope.ServiceProvider.GetRequiredService<IDispatchSender>();
+            await sender.SendDispatch((object)new SubscribedEvent { SomeNumber = 1, SomeString = "test" });
+        }
+
+        provider.GetRequiredService<FakeClientFactory>().GetSenderMock("myQueue").Should().BeNull();
+        await provider.SimulateStopHost(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task SendDispatch_Dispatch_WhenDisabled_DoesNotInvokeSender()
+    {
+        var provider = await CreateDisabledProviderAsync();
+
+        using (var scope = provider.CreateScope())
+        {
+            var sender = scope.ServiceProvider.GetRequiredService<IDispatchSender>();
+            await sender.SendDispatch(new Ev.ServiceBus.Abstractions.Dispatch(new SubscribedEvent { SomeNumber = 1, SomeString = "test" }));
+        }
+
+        provider.GetRequiredService<FakeClientFactory>().GetSenderMock("myQueue").Should().BeNull();
+        await provider.SimulateStopHost(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task SendDispatches_Objects_WhenDisabled_DoesNotInvokeSender()
+    {
+        var provider = await CreateDisabledProviderAsync();
+
+        using (var scope = provider.CreateScope())
+        {
+            var sender = scope.ServiceProvider.GetRequiredService<IDispatchSender>();
+            await sender.SendDispatches(new object[] { new SubscribedEvent { SomeNumber = 1, SomeString = "test" } });
+        }
+
+        provider.GetRequiredService<FakeClientFactory>().GetSenderMock("myQueue").Should().BeNull();
+        await provider.SimulateStopHost(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task SendDispatches_Dispatches_WhenDisabled_DoesNotInvokeSender()
+    {
+        var provider = await CreateDisabledProviderAsync();
+
+        using (var scope = provider.CreateScope())
+        {
+            var sender = scope.ServiceProvider.GetRequiredService<IDispatchSender>();
+            await sender.SendDispatches(new[] { new Ev.ServiceBus.Abstractions.Dispatch(new SubscribedEvent { SomeNumber = 1, SomeString = "test" }) });
+        }
+
+        provider.GetRequiredService<FakeClientFactory>().GetSenderMock("myQueue").Should().BeNull();
+        await provider.SimulateStopHost(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ScheduleDispatches_Objects_WhenDisabled_DoesNotInvokeSender()
+    {
+        var provider = await CreateDisabledProviderAsync();
+
+        using (var scope = provider.CreateScope())
+        {
+            var sender = scope.ServiceProvider.GetRequiredService<IDispatchSender>();
+            await sender.ScheduleDispatches(
+                new object[] { new SubscribedEvent { SomeNumber = 1, SomeString = "test" } },
+                DateTimeOffset.UtcNow.AddDays(1));
+        }
+
+        provider.GetRequiredService<FakeClientFactory>().GetSenderMock("myQueue").Should().BeNull();
+        await provider.SimulateStopHost(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ScheduleDispatches_Dispatches_WhenDisabled_DoesNotInvokeSender()
+    {
+        var provider = await CreateDisabledProviderAsync();
+
+        using (var scope = provider.CreateScope())
+        {
+            var sender = scope.ServiceProvider.GetRequiredService<IDispatchSender>();
+            await sender.ScheduleDispatches(
+                new[] { new Ev.ServiceBus.Abstractions.Dispatch(new SubscribedEvent { SomeNumber = 1, SomeString = "test" }) },
+                DateTimeOffset.UtcNow.AddDays(1));
+        }
+
+        provider.GetRequiredService<FakeClientFactory>().GetSenderMock("myQueue").Should().BeNull();
+        await provider.SimulateStopHost(CancellationToken.None);
+    }
+
+    // Null-argument checks must fire before IsDisabled() for all overloads that own them
+    [Fact]
+    public async Task SendDispatches_Objects_WhenDisabled_NullPayload_ThrowsArgumentNullException()
+    {
+        var provider = await CreateDisabledProviderAsync();
+
+        using (var scope = provider.CreateScope())
+        {
+            var sender = scope.ServiceProvider.GetRequiredService<IDispatchSender>();
+            await Assert.ThrowsAsync<ArgumentNullException>(() => sender.SendDispatches((IEnumerable<object>)null!));
+        }
+
+        await provider.SimulateStopHost(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task SendDispatches_Dispatches_WhenDisabled_NullPayload_ThrowsArgumentNullException()
+    {
+        var provider = await CreateDisabledProviderAsync();
+
+        using (var scope = provider.CreateScope())
+        {
+            var sender = scope.ServiceProvider.GetRequiredService<IDispatchSender>();
+            await Assert.ThrowsAsync<ArgumentNullException>(() => sender.SendDispatches((IEnumerable<Ev.ServiceBus.Abstractions.Dispatch>)null!));
+        }
+
+        await provider.SimulateStopHost(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ScheduleDispatches_Objects_WhenDisabled_NullPayload_ThrowsArgumentNullException()
+    {
+        var provider = await CreateDisabledProviderAsync();
+
+        using (var scope = provider.CreateScope())
+        {
+            var sender = scope.ServiceProvider.GetRequiredService<IDispatchSender>();
+            await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                sender.ScheduleDispatches((IEnumerable<object>)null!, DateTimeOffset.UtcNow.AddDays(1)));
+        }
+
+        await provider.SimulateStopHost(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ScheduleDispatches_Dispatches_WhenDisabled_NullPayload_ThrowsArgumentNullException()
+    {
+        var provider = await CreateDisabledProviderAsync();
+
+        using (var scope = provider.CreateScope())
+        {
+            var sender = scope.ServiceProvider.GetRequiredService<IDispatchSender>();
+            await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                sender.ScheduleDispatches((IEnumerable<Ev.ServiceBus.Abstractions.Dispatch>)null!, DateTimeOffset.UtcNow.AddDays(1)));
+        }
+
+        await provider.SimulateStopHost(CancellationToken.None);
+    }
+
     private void GivenIsolationKeyInMetadata(string isolationKey)
     {
         var appProperties = new Dictionary<string, object> { { UserProperties.IsolationKey , isolationKey } };
@@ -599,6 +752,24 @@ public class DispatchTest : IDisposable
             return _sentMessagesToQueueSession.FirstOrDefault();
         }
         return _sentMessagesToQueue.FirstOrDefault();
+    }
+
+    private static async Task<ServiceProvider> CreateDisabledProviderAsync()
+    {
+        var services = new ServiceCollection();
+        services.AddServiceBus(settings =>
+        {
+            settings.Enabled = false;
+            settings.WithConnection("Endpoint=testConnectionString;", new ServiceBusClientOptions());
+        });
+        services.OverrideClientFactory();
+        services.RegisterServiceBusDispatch().ToQueue("myQueue", builder =>
+        {
+            builder.RegisterDispatch<SubscribedEvent>();
+        });
+        var provider = services.BuildServiceProvider();
+        await provider.SimulateStartHost(CancellationToken.None);
+        return provider;
     }
 
     public void Dispose()


### PR DESCRIPTION
Added checks to ensure no messages are sent when the Service Bus is disabled. Included tests to verify correct behavior and updated the changelog.