### PR TITLE
fix(#446605): broaden shutdown OperationCanceledException guard in ReceiverWrapper

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.7.3
+- Fixed
+  - Corrected the shutdown `OperationCanceledException` guard introduced in 5.7.2. The previous guard checked `oce.CancellationToken.IsCancellationRequested`, which was always `false` because the Azure ServiceBus SDK raises `ProcessErrorAsync` with `CancellationToken.None` during processor shutdown. The guard now matches any `OperationCanceledException`, which is safe since genuine transport errors surface as `ServiceBusException`.
+
 ## 5.7.2
 - Fixed
   - Suppressed spurious `OperationCanceledException` / `TaskCanceledException` APM error entries during pod graceful shutdown. When the Service Bus receive loop is cancelled with a requested cancellation token, the exception is now logged at `Warning` level instead of `Error`.

--- a/src/Ev.ServiceBus/Management/Wrappers/ReceiverWrapper.cs
+++ b/src/Ev.ServiceBus/Management/Wrappers/ReceiverWrapper.cs
@@ -132,7 +132,7 @@ public class ReceiverWrapper
     /// <returns></returns>
     protected async Task OnExceptionOccured(ProcessErrorEventArgs exceptionEvent)
     {
-        if (exceptionEvent.Exception is OperationCanceledException oce && oce.CancellationToken.IsCancellationRequested)
+        if (exceptionEvent.Exception is OperationCanceledException)
         {
             _messageProcessingLogger.LogWarning(
                 "[Ev.ServiceBus] Receive loop cancelled for {ClientType} '{ResourceId}' during shutdown.",

--- a/tests/Ev.ServiceBus.UnitTests/ReceiverWrapperTests.cs
+++ b/tests/Ev.ServiceBus.UnitTests/ReceiverWrapperTests.cs
@@ -31,20 +31,44 @@ public sealed class ReceiverWrapperTests
     }
 
     [Fact]
-    public async Task OnExceptionOccured_WithCancelledToken_DoesNotLogError()
+    public async Task OnExceptionOccured_WithOperationCanceledException_DoesNotLogError()
     {
         var mockLogger = new Mock<ILogger<LoggingExtensions.MessageProcessing>>();
         var wrapper = CreateWrapper(mockLogger.Object);
 
-        using var cts = new CancellationTokenSource();
-        cts.Cancel();
-
+        // Azure SDK raises ProcessErrorAsync with CancellationToken.None during shutdown —
+        // the token on the exception is not the shutdown token, so IsCancellationRequested is false.
         var args = new ProcessErrorEventArgs(
-            new OperationCanceledException("shutdown", cts.Token),
+            new OperationCanceledException("shutdown", CancellationToken.None),
             ServiceBusErrorSource.Receive,
             "test-namespace",
             "test-queue",
-            cts.Token);
+            CancellationToken.None);
+
+        await wrapper.InvokeOnExceptionOccuredAsync(args);
+
+        mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => true),
+                It.IsAny<Exception?>(),
+                It.Is<Func<It.IsAnyType, Exception?, string>>((v, t) => true)),
+            Times.Never());
+    }
+
+    [Fact]
+    public async Task OnExceptionOccured_WithTaskCanceledException_DoesNotLogError()
+    {
+        var mockLogger = new Mock<ILogger<LoggingExtensions.MessageProcessing>>();
+        var wrapper = CreateWrapper(mockLogger.Object);
+
+        var args = new ProcessErrorEventArgs(
+            new TaskCanceledException(),
+            ServiceBusErrorSource.Receive,
+            "test-namespace",
+            "test-queue",
+            CancellationToken.None);
 
         await wrapper.InvokeOnExceptionOccuredAsync(args);
 


### PR DESCRIPTION
## Summary

- Removes `oce.CancellationToken.IsCancellationRequested` from the guard in `ReceiverWrapper.OnExceptionOccured`
- The Azure ServiceBus SDK raises `ProcessErrorAsync` with a `TaskCanceledException` whose `.CancellationToken` is `CancellationToken.None` during shutdown — the previous guard never fired
- Widening to any `OperationCanceledException` is safe: genuine transport errors surface as `ServiceBusException`, not `OperationCanceledException`
- Adds tests covering `CancellationToken.None` (the actual SDK case) and a dedicated `TaskCanceledException` variant

## Context

PR #204351 shipped as v5.7.2 with a guard checking `IsCancellationRequested`. Post-deployment APM analysis (ADO task #446605 / US #442484) confirmed 30 `TaskCanceledException` errors still appearing in a shutdown burst — the Azure SDK sets the token to `CancellationToken.None` internally so the guard was always `false`.

## Test plan

- [ ] `OnExceptionOccured_WithOperationCanceledException_DoesNotLogError` — SDK shutdown path with `CancellationToken.None`
- [ ] `OnExceptionOccured_WithTaskCanceledException_DoesNotLogError` — explicit `TaskCanceledException` case
- [ ] `OnExceptionOccured_WithNonCancelledToken_LogsError` — confirms genuine errors still log at Error