### PR TITLE
chore(#458163,#458177): add net10.0 target framework and bump to 5.8.0

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -11,22 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core 3.1
+    - name: Setup .NET 10
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.x
-    - name: Setup .NET 5
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 5.0.x
-    - name: Setup .NET 6
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
-    - name: Setup .NET 8
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -11,6 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Setup .NET 8
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 8.0.x
     - name: Setup .NET 10
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/publish-nugets.yml
+++ b/.github/workflows/publish-nugets.yml
@@ -9,22 +9,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup .NET Core 3.1
+      - name: Setup .NET 10
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.x
-      - name: Setup .NET 5
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 5.0.x
-      - name: Setup .NET 6
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 6.0.x
-      - name: Setup .NET 8
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/publish-nugets.yml
+++ b/.github/workflows/publish-nugets.yml
@@ -9,6 +9,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 8.0.x
       - name: Setup .NET 10
         uses: actions/setup-dotnet@v1
         with:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,20 +26,20 @@
   </PropertyGroup>
 
   <ItemGroup Label="UnitTest project references" Condition="'$(IsUnitTestProject)' == 'true'">
-    <PackageReference Include="coverlet.msbuild" Version="3.0.2">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
 
-    <PackageReference Include="Moq" Version="4.16.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4"/>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="FluentAssertions" Version="5.7.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1"/>
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="FluentAssertions" Version="7.2.2" />
   </ItemGroup>
 
 </Project>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 6.0.0
+## 5.8.0
+- Added
+  - `net10.0` added as an additional target framework across `Ev.ServiceBus`, `Ev.ServiceBus.Abstractions`, `Ev.ServiceBus.Apm`, `Ev.ServiceBus.AsyncApi`, `Ev.ServiceBus.HealthChecks`, `Ev.ServiceBus.Mvc`, and `Ev.ServiceBus.Prometheus`, alongside the existing `net8.0` (and `netstandard2.0`/`netstandard2.1` on the core packages). Non-breaking — existing net8.0 consumers are unaffected.
 - Changed
-  - **Breaking:** `Ev.ServiceBus.Apm`, `Ev.ServiceBus.AsyncApi`, `Ev.ServiceBus.HealthChecks`, `Ev.ServiceBus.Mvc`, and `Ev.ServiceBus.Prometheus` now target `net10.0` instead of `net8.0`. Consumers on net8.0/net9.0 must upgrade to net10.0 to use 6.0.0+, or stay on the 5.x line.
-  - `Ev.ServiceBus` and `Ev.ServiceBus.Abstractions` now multi-target `netstandard2.1;netstandard2.0;net10.0` (`net8.0` replaced by `net10.0`; `netstandard2.0`/`netstandard2.1` kept unchanged for existing non-.NET-10 consumers).
   - `Ev.ServiceBus.Mvc` no longer references the legacy `Microsoft.AspNetCore.Mvc.Abstractions`/`Microsoft.AspNetCore.Mvc.Core` 2.2.x NuGet packages — it now uses a `FrameworkReference` to `Microsoft.AspNetCore.App`, matching the ASP.NET Core shared-framework model used since .NET Core 3.0.
-  - Bumped `Azure.Identity` to 1.17.1 (1.17.0 was deprecated), `Microsoft.Extensions.*` to 10.0.9, `Elastic.Apm` to 1.34.5, `AspNetCore.HealthChecks.AzureServiceBus` to 9.0.0.
+  - Bumped `Azure.Identity` to 1.17.1 (1.17.0 was deprecated), `Elastic.Apm` to 1.34.5, `AspNetCore.HealthChecks.AzureServiceBus` to 9.0.0.
 
 ## 5.7.5
 - Fixed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.0.0
+- Changed
+  - **Breaking:** `Ev.ServiceBus.Apm`, `Ev.ServiceBus.AsyncApi`, `Ev.ServiceBus.HealthChecks`, `Ev.ServiceBus.Mvc`, and `Ev.ServiceBus.Prometheus` now target `net10.0` instead of `net8.0`. Consumers on net8.0/net9.0 must upgrade to net10.0 to use 6.0.0+, or stay on the 5.x line.
+  - `Ev.ServiceBus` and `Ev.ServiceBus.Abstractions` now multi-target `netstandard2.1;netstandard2.0;net10.0` (`net8.0` replaced by `net10.0`; `netstandard2.0`/`netstandard2.1` kept unchanged for existing non-.NET-10 consumers).
+  - `Ev.ServiceBus.Mvc` no longer references the legacy `Microsoft.AspNetCore.Mvc.Abstractions`/`Microsoft.AspNetCore.Mvc.Core` 2.2.x NuGet packages — it now uses a `FrameworkReference` to `Microsoft.AspNetCore.App`, matching the ASP.NET Core shared-framework model used since .NET Core 3.0.
+  - Bumped `Azure.Identity` to 1.17.1 (1.17.0 was deprecated), `Microsoft.Extensions.*` to 10.0.9, `Elastic.Apm` to 1.34.5, `AspNetCore.HealthChecks.AzureServiceBus` to 9.0.0.
+
 ## 5.7.5
 - Fixed
   - `ApmTransactionManager` now registers the APM error filter **at construction time** (application startup) instead of lazily inside `OnReceiveCancelled()`. The lazy approach lost a race: during pod graceful shutdown the APM agent flushes its internal buffer concurrently with Service Bus processor teardown, so error events could be sent to APM before `ReceiverWrapper.OnExceptionOccured` ran and had a chance to register the filter. Registering at construction time — before any message processing starts — closes this window.

--- a/samples/Ev.ServiceBus.Aspire.Host/Ev.ServiceBus.Aspire.Host.csproj
+++ b/samples/Ev.ServiceBus.Aspire.Host/Ev.ServiceBus.Aspire.Host.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <Sdk Name="Aspire.AppHost.Sdk" Version="9.3.0"/>
+    <Sdk Name="Aspire.AppHost.Sdk" Version="13.4.6"/>
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <UserSecretsId>107e167e-5575-4f6e-8661-fe8d2c335f7a</UserSecretsId>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="9.3.0"/>
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/Ev.ServiceBus.Aspire.ServiceDefault/Ev.ServiceBus.Aspire.ServiceDefault.csproj
+++ b/samples/Ev.ServiceBus.Aspire.ServiceDefault/Ev.ServiceBus.Aspire.ServiceDefault.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsAspireSharedProject>true</IsAspireSharedProject>

--- a/samples/Ev.ServiceBus.Sample.Contracts/Ev.ServiceBus.Sample.Contracts.csproj
+++ b/samples/Ev.ServiceBus.Sample.Contracts/Ev.ServiceBus.Sample.Contracts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/Ev.ServiceBus.Samples.Receiver/Ev.ServiceBus.Samples.Receiver.csproj
+++ b/samples/Ev.ServiceBus.Samples.Receiver/Ev.ServiceBus.Samples.Receiver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <SonarQubeExclude>true</SonarQubeExclude>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/samples/Ev.ServiceBus.Samples.Sender/Ev.ServiceBus.Samples.Sender.csproj
+++ b/samples/Ev.ServiceBus.Samples.Sender/Ev.ServiceBus.Samples.Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <SonarQubeExclude>true</SonarQubeExclude>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Ev.ServiceBus.Abstractions/Ev.ServiceBus.Abstractions.csproj
+++ b/src/Ev.ServiceBus.Abstractions/Ev.ServiceBus.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net10.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Description>
@@ -14,7 +14,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.17.0" />
+    <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
   </ItemGroup>
 
@@ -22,9 +22,9 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
   </ItemGroup>
 </Project>

--- a/src/Ev.ServiceBus.Abstractions/Ev.ServiceBus.Abstractions.csproj
+++ b/src/Ev.ServiceBus.Abstractions/Ev.ServiceBus.Abstractions.csproj
@@ -28,6 +28,6 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
   </ItemGroup>
 </Project>

--- a/src/Ev.ServiceBus.Abstractions/Ev.ServiceBus.Abstractions.csproj
+++ b/src/Ev.ServiceBus.Abstractions/Ev.ServiceBus.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Description>
@@ -22,9 +22,12 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Ev.ServiceBus.Apm/Ev.ServiceBus.Apm.csproj
+++ b/src/Ev.ServiceBus.Apm/Ev.ServiceBus.Apm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <IsPackable>true</IsPackable>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Description>This package helps you add instrumentation to message handling with Elastic APM.</Description>

--- a/src/Ev.ServiceBus.Apm/Ev.ServiceBus.Apm.csproj
+++ b/src/Ev.ServiceBus.Apm/Ev.ServiceBus.Apm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IsPackable>true</IsPackable>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Description>This package helps you add instrumentation to message handling with Elastic APM.</Description>
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Elastic.Apm" Version="1.19.0" />
+      <PackageReference Include="Elastic.Apm" Version="1.34.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Ev.ServiceBus.AsyncApi/Ev.ServiceBus.AsyncApi.csproj
+++ b/src/Ev.ServiceBus.AsyncApi/Ev.ServiceBus.AsyncApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IsPackable>true</IsPackable>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Description>This package helps you generate an Async API Schema.

--- a/src/Ev.ServiceBus.AsyncApi/Ev.ServiceBus.AsyncApi.csproj
+++ b/src/Ev.ServiceBus.AsyncApi/Ev.ServiceBus.AsyncApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <IsPackable>true</IsPackable>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Description>This package helps you generate an Async API Schema.

--- a/src/Ev.ServiceBus.HealthChecks/Ev.ServiceBus.HealthChecks.csproj
+++ b/src/Ev.ServiceBus.HealthChecks/Ev.ServiceBus.HealthChecks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IsPackable>true</IsPackable>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Description>This package links Ev.ServiceBus and Microsoft.Extensions.Diagnostics.HealthChecks NuGet packages. 
@@ -12,8 +12,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AspNetCore.HealthChecks.AzureServiceBus" Version="8.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0" />
+        <PackageReference Include="AspNetCore.HealthChecks.AzureServiceBus" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/Ev.ServiceBus.HealthChecks/Ev.ServiceBus.HealthChecks.csproj
+++ b/src/Ev.ServiceBus.HealthChecks/Ev.ServiceBus.HealthChecks.csproj
@@ -13,7 +13,13 @@
 
     <ItemGroup>
         <PackageReference Include="AspNetCore.HealthChecks.AzureServiceBus" Version="9.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.11" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/Ev.ServiceBus.HealthChecks/Ev.ServiceBus.HealthChecks.csproj
+++ b/src/Ev.ServiceBus.HealthChecks/Ev.ServiceBus.HealthChecks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <IsPackable>true</IsPackable>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Description>This package links Ev.ServiceBus and Microsoft.Extensions.Diagnostics.HealthChecks NuGet packages. 
@@ -13,7 +13,7 @@
 
     <ItemGroup>
         <PackageReference Include="AspNetCore.HealthChecks.AzureServiceBus" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.11" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/Ev.ServiceBus.Mvc/Ev.ServiceBus.Mvc.csproj
+++ b/src/Ev.ServiceBus.Mvc/Ev.ServiceBus.Mvc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <IsPackable>true</IsPackable>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Description>This NuGet contains helpers to better integrate Ev.ServiceBus with Mvc projects.</Description>

--- a/src/Ev.ServiceBus.Mvc/Ev.ServiceBus.Mvc.csproj
+++ b/src/Ev.ServiceBus.Mvc/Ev.ServiceBus.Mvc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IsPackable>true</IsPackable>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Description>This NuGet contains helpers to better integrate Ev.ServiceBus with Mvc projects.</Description>
@@ -15,8 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+      <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
 
 </Project>

--- a/src/Ev.ServiceBus.Prometheus/Ev.ServiceBus.Prometheus.csproj
+++ b/src/Ev.ServiceBus.Prometheus/Ev.ServiceBus.Prometheus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IsPackable>true</IsPackable>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Description>This package helps you add prometheus meters on top of servicebus messaging.</Description>
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
       <PackageReference Include="prometheus-net" Version="8.2.1" />
     </ItemGroup>
 

--- a/src/Ev.ServiceBus.Prometheus/Ev.ServiceBus.Prometheus.csproj
+++ b/src/Ev.ServiceBus.Prometheus/Ev.ServiceBus.Prometheus.csproj
@@ -11,8 +11,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
       <PackageReference Include="prometheus-net" Version="8.2.1" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Ev.ServiceBus.Prometheus/Ev.ServiceBus.Prometheus.csproj
+++ b/src/Ev.ServiceBus.Prometheus/Ev.ServiceBus.Prometheus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <IsPackable>true</IsPackable>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Description>This package helps you add prometheus meters on top of servicebus messaging.</Description>
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
       <PackageReference Include="prometheus-net" Version="8.2.1" />
     </ItemGroup>
 

--- a/src/Ev.ServiceBus/Ev.ServiceBus.csproj
+++ b/src/Ev.ServiceBus/Ev.ServiceBus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net10.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Description>This is a wrapper around Microsoft Azure Service Bus
@@ -22,14 +22,14 @@ Its goal to is make it the easiest possible to connect and handle an Azure Servi
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1' ">
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Ev.ServiceBus.Abstractions\Ev.ServiceBus.Abstractions.csproj" />

--- a/src/Ev.ServiceBus/Ev.ServiceBus.csproj
+++ b/src/Ev.ServiceBus/Ev.ServiceBus.csproj
@@ -32,9 +32,9 @@ Its goal to is make it the easiest possible to connect and handle an Azure Servi
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Ev.ServiceBus.Abstractions\Ev.ServiceBus.Abstractions.csproj" />

--- a/src/Ev.ServiceBus/Ev.ServiceBus.csproj
+++ b/src/Ev.ServiceBus/Ev.ServiceBus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Description>This is a wrapper around Microsoft Azure Service Bus
@@ -22,14 +22,19 @@ Its goal to is make it the easiest possible to connect and handle an Azure Servi
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1' ">
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Ev.ServiceBus.Abstractions\Ev.ServiceBus.Abstractions.csproj" />

--- a/tests/Ev.ServiceBus.AsyncApi.UnitTests/DocumentFilterTest.cs
+++ b/tests/Ev.ServiceBus.AsyncApi.UnitTests/DocumentFilterTest.cs
@@ -1,7 +1,7 @@
+using System.Net;
 using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Microsoft.AspNetCore.Http;
 using Xunit;
 
 namespace Ev.ServiceBus.AsyncApi.UnitTests;
@@ -15,7 +15,7 @@ public class DocumentFilterTest
         var client = factory.CreateClient();
         var response = await client.GetAsync("/asyncapi/asyncapi.json");
 
-        response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var json = await response.Content.ReadAsStringAsync();
 
         var actualDoc = JsonDocument.Parse(json);
@@ -295,7 +295,7 @@ public class DocumentFilterTest
         var factory = new ReceiverAppFactory();
         var client = factory.CreateClient();
         var response = await client.GetAsync("/asyncapi/asyncapi.json");
-        response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var json = await response.Content.ReadAsStringAsync();
         var actualDoc = JsonDocument.Parse(json);

--- a/tests/Ev.ServiceBus.AsyncApi.UnitTests/Ev.ServiceBus.AsyncApi.UnitTests.csproj
+++ b/tests/Ev.ServiceBus.AsyncApi.UnitTests/Ev.ServiceBus.AsyncApi.UnitTests.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
     
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Ev.ServiceBus.HealthChecks.UnitTests/Ev.ServiceBus.HealthChecks.UnitTests.csproj
+++ b/tests/Ev.ServiceBus.HealthChecks.UnitTests/Ev.ServiceBus.HealthChecks.UnitTests.csproj
@@ -10,7 +10,10 @@
       <ProjectReference Include="..\Ev.ServiceBus.TestHelpers\Ev.ServiceBus.TestHelpers.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     </ItemGroup>
 </Project>

--- a/tests/Ev.ServiceBus.HealthChecks.UnitTests/Ev.ServiceBus.HealthChecks.UnitTests.csproj
+++ b/tests/Ev.ServiceBus.HealthChecks.UnitTests/Ev.ServiceBus.HealthChecks.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
@@ -11,6 +11,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     </ItemGroup>
 </Project>

--- a/tests/Ev.ServiceBus.HealthChecks.UnitTests/Ev.ServiceBus.HealthChecks.UnitTests.csproj
+++ b/tests/Ev.ServiceBus.HealthChecks.UnitTests/Ev.ServiceBus.HealthChecks.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
@@ -11,6 +11,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     </ItemGroup>
 </Project>

--- a/tests/Ev.ServiceBus.Mvc.UnitTests/DispatchTest.cs
+++ b/tests/Ev.ServiceBus.Mvc.UnitTests/DispatchTest.cs
@@ -1,11 +1,11 @@
-﻿using System.Threading;
+﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
 using Ev.ServiceBus.Samples.Sender;
 using Ev.ServiceBus.UnitTests.Helpers;
 using FluentAssertions;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Logging;
@@ -23,7 +23,7 @@ public class DispatchTest
         var client = factory.CreateClient();
         var response = await client.GetAsync("weatherforecast/pushWeather");
 
-        response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var queue = factory.Services.GetSenderMock("myqueue");
         queue.Mock.Verify(o => o.SendMessagesAsync(It.IsAny<ServiceBusMessageBatch>(), It.IsAny<CancellationToken>()), Times.Once);
 
@@ -38,7 +38,7 @@ public class DispatchTest
         var client = factory.CreateClient();
         var response = await client.GetAsync("failing/pushWeather");
 
-        response.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+        response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
         var queue = factory.Services.GetSenderMock("myqueue");
         queue.Mock.Verify(o => o.SendMessagesAsync(It.IsAny<ServiceBusMessage[]>(), It.IsAny<CancellationToken>()), Times.Never);
 

--- a/tests/Ev.ServiceBus.Mvc.UnitTests/Ev.ServiceBus.Mvc.UnitTests.csproj
+++ b/tests/Ev.ServiceBus.Mvc.UnitTests/Ev.ServiceBus.Mvc.UnitTests.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
     </ItemGroup>
     
     <ItemGroup>

--- a/tests/Ev.ServiceBus.TestHelpers/Ev.ServiceBus.TestHelpers.csproj
+++ b/tests/Ev.ServiceBus.TestHelpers/Ev.ServiceBus.TestHelpers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
@@ -10,9 +10,6 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Moq" Version="4.20.72" />
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     </ItemGroup>
 </Project>

--- a/tests/Ev.ServiceBus.TestHelpers/Ev.ServiceBus.TestHelpers.csproj
+++ b/tests/Ev.ServiceBus.TestHelpers/Ev.ServiceBus.TestHelpers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
@@ -9,10 +9,10 @@
       <ProjectReference Include="..\..\src\Ev.ServiceBus\Ev.ServiceBus.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Moq" Version="4.16.0" />
+        <PackageReference Include="Moq" Version="4.20.72" />
     </ItemGroup>
-    
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     </ItemGroup>
 </Project>

--- a/tests/Ev.ServiceBus.TestHelpers/Ev.ServiceBus.TestHelpers.csproj
+++ b/tests/Ev.ServiceBus.TestHelpers/Ev.ServiceBus.TestHelpers.csproj
@@ -10,6 +10,12 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Moq" Version="4.20.72" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     </ItemGroup>
 </Project>

--- a/tests/Ev.ServiceBus.UnitTests/Ev.ServiceBus.UnitTests.csproj
+++ b/tests/Ev.ServiceBus.UnitTests/Ev.ServiceBus.UnitTests.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <NoWarn>CS0618</NoWarn>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Scrutor" Version="4.2.2" />
+    <PackageReference Include="Scrutor" Version="7.0.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/tests/Ev.ServiceBus.UnitTests/Ev.ServiceBus.UnitTests.csproj
+++ b/tests/Ev.ServiceBus.UnitTests/Ev.ServiceBus.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <NoWarn>CS0618</NoWarn>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- Adds `net10.0` as an additional target framework alongside `net8.0` (and `netstandard2.0`/`netstandard2.1` on the two core packages) across all 7 packable `src/` projects — non-breaking, existing net8.0 consumers unaffected
- Samples move fully to `net10.0` (dev-only, not published)
- Tests multi-target `net8.0;net10.0` where possible (`UnitTests`, `HealthChecks.UnitTests`, `TestHelpers`); `AsyncApi.UnitTests`/`Mvc.UnitTests` stay net10.0-only since they reference the now net10.0-only sample projects
- Bumps `Azure.Identity` (1.17.0 was deprecated), `Elastic.Apm`, `AspNetCore.HealthChecks.AzureServiceBus` (and its `Microsoft.Extensions.Diagnostics.HealthChecks` floor to 8.0.11 to avoid a NU1605 downgrade error)
- Bumps test tooling (Moq, Microsoft.NET.Test.Sdk, coverlet, FluentAssertions capped at 7.2.2 to avoid the v8+ commercial license, xunit kept on the v2 line)
- Replaces `Ev.ServiceBus.Mvc`'s legacy `Microsoft.AspNetCore.Mvc.Abstractions`/`.Core` 2.2.x package refs with a `FrameworkReference` to `Microsoft.AspNetCore.App`
- Collapses the CI workflows' dead 3.1/5.0/6.0/8.0 SDK setup steps into a single .NET 10 setup step
- Version bump to 5.8.0 (minor, non-breaking), CHANGELOG updated

Related: US #458163, Task #458177

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — all pass across net8.0 and net10.0 (344 total test runs, 0 failures)
